### PR TITLE
Feat/ofb ctr

### DIFF
--- a/crypto-cli/src/cli_config.cpp
+++ b/crypto-cli/src/cli_config.cpp
@@ -110,8 +110,12 @@ CryptoConfig ArgumentParser::parse() {
                 this->config.operation_mode = AESencryption::Cipher::OperationMode::Identifier::ECB;
             } else if (mode == "CBC") {
                 this->config.operation_mode = AESencryption::Cipher::OperationMode::Identifier::CBC;
+            } else if (mode == "OFB") {
+                this->config.operation_mode = AESencryption::Cipher::OperationMode::Identifier::OFB;
+            } else if (mode == "CTR") {
+                this->config.operation_mode = AESencryption::Cipher::OperationMode::Identifier::CTR;
             } else {
-                this->config.error_message = "Invalid mode: " + mode + ". Use ECB or CBC.";
+                this->config.error_message = "Invalid mode: " + mode + ". Use ECB, CBC, OFB, or CTR.";
                 this->config.is_valid = false;
                 return this->config;
             }
@@ -172,7 +176,7 @@ void ArgumentParser::print_help() const{
               << "\tKey Generation:\t" << this->argv[0] << " --generate-key --key-length <bits> --output <file>\n\n"
               << "Options:\n"
               << "\t--key-length <bits>      Key length: 128, 192, or 256 (default: 128)\n"
-              << "\t--mode <ECB|CBC>         Operation mode (default: CBC)\n"
+              << "\t--mode <ECB|CBC|OFB|CTR> Operation mode (default: CBC)\n"
               << "\t--mode-data <file>       Required data for specific operation mode\n"
               << "\t--show-metrics           Show statistical metrics from input and output\n"
               << "\t--help                   Show this help message\n";

--- a/data-encryption/include/operation_modes.h
+++ b/data-encryption/include/operation_modes.h
@@ -1,13 +1,13 @@
 /**
  * @file operation_modes.h
- * @brief AES block cipher operation modes (ECB CBC, and OFB)
+ * @brief AES block cipher operation modes (ECB CBC, OFB, and CTR)
  *
  * This file provides AES encryption and decryption functions using
- * Electronic Codebook (ECB), Cipher Block Chaining (CBC) and Output Feedback Mode (OFB) operation modes.
+ * Electronic Codebook (ECB), Cipher Block Chaining (CBC), Output Feedback Mode (OFB) and Counter (CTR) operation modes.
  * Each modes operate on 16-byte blocks (128 bits).
  *
  * @note All functions support in-place operation when input == output
- * @note All input sizes must be multiples of 16 bytes (AES block size)
+ * @note All input sizes for ECB and CBC must be multiples of 16 bytes (AES block size)
  * @note The IV for CBC mode must be exactly 16 bytes
  */
 
@@ -162,12 +162,153 @@ enum ExceptionCode encryptCBC(const uint8_t*const input, size_t size, const uint
 */
 enum ExceptionCode decryptCBC(const uint8_t*const input, size_t size, const uint8_t* keyexpansion, size_t keylenbits, const uint8_t* IV, uint8_t*const output);
 
+/**
+* @brief Encrypts data using AES-OFB (Output Feedback) operation mode
+*
+* Encrypts the data pointed to by 'input' using AES-OFB operation mode with
+* the provided initialization vector (IV). OFB generates a keystream by
+* repeatedly encrypting the IV, then XORs it with the plaintext. Encryption
+* and decryption are identical operations (same keystream applied via XOR).
+*
+* @param[in] input Pointer to the input data to be encrypted
+* @param[in] size Size of the input data in bytes
+* @param[in] keyexpansion Pointer to the expanded AES key schedule
+* @param[in] keylenbits AES key length in bits (128, 192, or 256)
+* @param[in] IV Pointer to the 16-byte initialization vector for OFB mode
+* @param[out] output Pointer to the output buffer for encrypted data
+*                    (must have at least 'size' bytes available)
+*
+* @return ExceptionCode indicating success or failure
+* @retval NoException Operation completed successfully
+* @retval NullInput The input pointer is NULL
+* @retval NullOutput The output pointer is NULL
+* @retval NullKeyExpansion The keyexpansion pointer is NULL
+* @retval NullInitialVector The IV pointer is NULL
+* @retval ZeroLength The size parameter is zero
+* @retval InvalidKeyLength The keylenbits is not 128, 192, or 256
+*
+* @note If input == output (same memory location), the input data will be
+*       overwritten with the encrypted data (in-place encryption)
+* @note The IV should be unpredictable (ideally cryptographically random)
+*       and unique for each encryption operation with the same key
+* @note The IV must be exactly 16 bytes (128 bits) to match the AES block size
+* @note OFB supports partial blocks: size does not need to be a multiple of 16
+* @note OFB is a stream cipher mode: encryption and decryption use the same
+*       function (encryptOFB == decryptOFB in effect)
+*
+* @see decryptOFB()
+* @see encryptCBC()
+*/
 enum ExceptionCode encryptOFB(const uint8_t*const input, size_t size, const uint8_t* keyexpansion, size_t keylenbits, const uint8_t* IV, uint8_t*const output);
 
+/**
+* @brief Decrypts data using AES-OFB (Output Feedback) operation mode
+*
+* Decrypts the data pointed to by 'input' using AES-OFB operation mode with
+* the initialization vector (IV) that was used during encryption. Because OFB
+* generates an independent keystream, decryption is identical to encryption:
+* both operations XOR the data with the same keystream derived from the IV.
+*
+* @param[in] input Pointer to the encrypted input data
+* @param[in] size Size of the input data in bytes
+* @param[in] keyexpansion Pointer to the expanded AES key schedule
+* @param[in] keylenbits AES key length in bits (128, 192, or 256)
+* @param[in] IV Pointer to the 16-byte initialization vector used during encryption
+* @param[out] output Pointer to the output buffer for decrypted data
+*                    (must have at least 'size' bytes available)
+*
+* @return ExceptionCode indicating success or failure
+* @retval NoException Operation completed successfully
+* @retval NullInput The input pointer is NULL
+* @retval NullOutput The output pointer is NULL
+* @retval NullKeyExpansion The keyexpansion pointer is NULL
+* @retval NullInitialVector The IV pointer is NULL
+* @retval ZeroLength The size parameter is zero
+* @retval InvalidKeyLength The keylenbits is not 128, 192, or 256
+*
+* @note If input == output (same memory location), the input data will be
+*       overwritten with the decrypted data (in-place decryption)
+* @note The IV must be exactly the same 16-byte value used during encryption
+* @note The same key and key length used for encryption must be used
+* @note OFB supports partial blocks: size does not need to be a multiple of 16
+*
+* @see encryptOFB()
+* @see decryptCBC()
+*/
 enum ExceptionCode decryptOFB(const uint8_t*const input, size_t size, const uint8_t* keyexpansion, size_t keylenbits, const uint8_t* IV, uint8_t*const output);
 
+/**
+* @brief Encrypts data using AES-CTR (Counter) operation mode
+*
+* Encrypts the data pointed to by 'input' using AES-CTR operation mode with
+* the provided initial counter block. CTR generates a keystream by encrypting
+* successive counter values and XORing with the plaintext. The counter is
+* incremented as a 64-bit little-endian integer after each block.
+*
+* @param[in] input Pointer to the input data to be encrypted
+* @param[in] size Size of the input data in bytes
+* @param[in] keyexpansion Pointer to the expanded AES key schedule
+* @param[in] keylenbits AES key length in bits (128, 192, or 256)
+* @param[in] counter00 Pointer to the 16-byte initial counter block
+* @param[out] output Pointer to the output buffer for encrypted data
+*                    (must have at least 'size' bytes available)
+*
+* @return ExceptionCode indicating success or failure
+* @retval NoException Operation completed successfully
+* @retval NullInput The input pointer is NULL
+* @retval NullOutput The output pointer is NULL
+* @retval NullKeyExpansion The keyexpansion pointer is NULL
+* @retval NullInitialVector The counter00 pointer is NULL
+* @retval ZeroLength The size parameter is zero
+* @retval InvalidKeyLength The keylenbits is not 128, 192, or 256
+*
+* @note If input == output (same memory location), the input data will be
+*       overwritten with the encrypted data (in-place encryption)
+* @note The counter block is incremented as a 64-bit little-endian integer
+*       for each successive block
+* @note CTR supports partial blocks: size does not need to be a multiple of 16
+* @note CTR is a stream cipher mode: encryption and decryption use the same
+*       function (encryptCTR == decryptCTR in effect)
+*
+* @see decryptCTR()
+* @see encryptOFB()
+*/
 enum ExceptionCode encryptCTR(const uint8_t*const input, size_t size, const uint8_t* keyexpansion, size_t keylenbits, const uint8_t* counter00, uint8_t*const output);
 
+/**
+* @brief Decrypts data using AES-CTR (Counter) operation mode
+*
+* Decrypts the data pointed to by 'input' using AES-CTR operation mode with
+* the initial counter block that was used during encryption. Because CTR
+* generates an independent keystream, decryption is identical to encryption:
+* both operations XOR the data with the same keystream derived from the counter.
+*
+* @param[in] input Pointer to the encrypted input data
+* @param[in] size Size of the input data in bytes
+* @param[in] keyexpansion Pointer to the expanded AES key schedule
+* @param[in] keylenbits AES key length in bits (128, 192, or 256)
+* @param[in] counter00 Pointer to the 16-byte initial counter block used during encryption
+* @param[out] output Pointer to the output buffer for decrypted data
+*                    (must have at least 'size' bytes available)
+*
+* @return ExceptionCode indicating success or failure
+* @retval NoException Operation completed successfully
+* @retval NullInput The input pointer is NULL
+* @retval NullOutput The output pointer is NULL
+* @retval NullKeyExpansion The keyexpansion pointer is NULL
+* @retval NullInitialVector The counter00 pointer is NULL
+* @retval ZeroLength The size parameter is zero
+* @retval InvalidKeyLength The keylenbits is not 128, 192, or 256
+*
+* @note If input == output (same memory location), the input data will be
+*       overwritten with the decrypted data (in-place decryption)
+* @note The counter00 must be exactly the same 16-byte value used during encryption
+* @note The same key and key length used for encryption must be used
+* @note CTR supports partial blocks: size does not need to be a multiple of 16
+*
+* @see encryptCTR()
+* @see decryptOFB()
+*/
 enum ExceptionCode decryptCTR(const uint8_t*const input, size_t size, const uint8_t* keyexpansion, size_t keylenbits, const uint8_t* counter00, uint8_t*const output);
 
 #ifdef __cplusplus

--- a/data-encryption/src/key_expansion.c
+++ b/data-encryption/src/key_expansion.c
@@ -235,7 +235,7 @@ bool compareKeyExpansionBytes(const KeyExpansion_t*const input, const uint8_t by
   bool result = true;
   // Constant time comparison. Preventing timing attacks.
   for(size_t i = 0, j = 0; i < input->blockSize; i++, j += BLOCK_SIZE){
-    result &= compareBlockBytes(input->dataBlocks + i, bytes + i);
+    result &= compareBlockBytes(input->dataBlocks + i, bytes + j);
   }
   return result;
 }

--- a/data-encryption/src/operation_modes.c
+++ b/data-encryption/src/operation_modes.c
@@ -474,6 +474,7 @@ static void encryptCTR__(const KeyExpansion_t* ke_p, const uint8_t* counter00, s
   for(size_t i = 0; i < is->info.tailSize; i++){                // -Encrypting tail of the stream.
     os->currentPossition[i] ^= counter.uint08_[i];
   }
+  BlockDestroy(&buffer);
 }
 
 enum ExceptionCode encryptCTR(const uint8_t*const input, size_t size, const uint8_t* keyexpansion, size_t keylenbits, const uint8_t* counter00, uint8_t*const output){

--- a/include/cipher.hpp
+++ b/include/cipher.hpp
@@ -24,6 +24,8 @@ public:
 			Unknown,
 			ECB,							// -Electronic Code Book (not recommended).
 			CBC,							// -Cipher Block Chaining.
+			OFB,							// -Output Feedback.
+			CTR,							// -Counter.
 		};
 	private:
 		Identifier ID_ = Identifier::ECB;

--- a/src/core/cipher.cpp
+++ b/src/core/cipher.cpp
@@ -89,29 +89,9 @@ Cipher::OperationMode::OperationMode(Identifier ID) : ID_(ID){
     switch(ID){
         case Identifier::ECB:
             break;
-        case Identifier::CBC: {     // Initialize initial vector with encrypted block
-            union {
-                uint8_t  data08[KEY_EXPANSION_LENGTH_128_BYTES];
-                uint64_t data64[KEY_EXPANSION_LENGTH_128_UINT64];
-            } dummyKeyExpansion;
-
-            // Initializing dummy key expansion with current time
-            uint64_t initialValue = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-            for(size_t i = 0; i < KEY_EXPANSION_LENGTH_128_UINT64; i++) dummyKeyExpansion.data64[i] = initialValue++;
-            union {
-                uint8_t  data08[BLOCK_SIZE];
-                uint64_t data64[2];
-            } dummyBlock;
-            // Initialize dummy block with current time
-            dummyBlock.data64[0] = initialValue++;
-            dummyBlock.data64[1] = initialValue;
-            // Creating initial vector with the encryption of the dummy block with the dummy key expansion
-            this->IV_ = new InitVector;
-            encryptECB(dummyBlock.data08, BLOCK_SIZE, dummyKeyExpansion.data08, 128, this->IV_->data);
-            break;
-        }
+        case Identifier::CBC:
         case Identifier::OFB:
-        case Identifier::CTR: {     // Initialize initial vector with encrypted block
+        case Identifier::CTR: {     // Initialize initial vector/counter with encrypted block
             union {
                 uint8_t  data08[KEY_EXPANSION_LENGTH_128_BYTES];
                 uint64_t data64[KEY_EXPANSION_LENGTH_128_UINT64];

--- a/src/core/cipher.cpp
+++ b/src/core/cipher.cpp
@@ -110,6 +110,25 @@ Cipher::OperationMode::OperationMode(Identifier ID) : ID_(ID){
             encryptECB(dummyBlock.data08, BLOCK_SIZE, dummyKeyExpansion.data08, 128, this->IV_->data);
             break;
         }
+        case Identifier::OFB:
+        case Identifier::CTR: {     // Initialize initial vector with encrypted block
+            union {
+                uint8_t  data08[KEY_EXPANSION_LENGTH_128_BYTES];
+                uint64_t data64[KEY_EXPANSION_LENGTH_128_UINT64];
+            } dummyKeyExpansion;
+
+            uint64_t initialValue = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+            for(size_t i = 0; i < KEY_EXPANSION_LENGTH_128_UINT64; i++) dummyKeyExpansion.data64[i] = initialValue++;
+            union {
+                uint8_t  data08[BLOCK_SIZE];
+                uint64_t data64[2];
+            } dummyBlock;
+            dummyBlock.data64[0] = initialValue++;
+            dummyBlock.data64[1] = initialValue;
+            this->IV_ = new InitVector;
+            encryptECB(dummyBlock.data08, BLOCK_SIZE, dummyKeyExpansion.data08, 128, this->IV_->data);
+            break;
+        }
         case Identifier::Unknown:
             break;
     }
@@ -159,6 +178,10 @@ const char* Cipher::OperationMode::identifier_to_string(Identifier ID){
             return "ECB";
         case Identifier::CBC:
             return "CBC";
+        case Identifier::OFB:
+            return "OFB";
+        case Identifier::CTR:
+            return "CTR";
     }
     return "Unknown";
 }
@@ -168,6 +191,10 @@ Cipher::OperationMode::Identifier Cipher::OperationMode::string_to_identifier(co
         return Identifier::ECB;
     if(str == "CBC")
         return Identifier::CBC;
+    if(str == "OFB")
+        return Identifier::OFB;
+    if(str == "CTR")
+        return Identifier::CTR;
 
     return Identifier::Unknown;
 }
@@ -186,6 +213,8 @@ void Cipher::OperationMode::save(const std::string& filepath) const{
             case Identifier::ECB:
                 break;
             case Identifier::CBC:
+            case Identifier::OFB:
+            case Identifier::CTR:
                 file.write(reinterpret_cast<const char*>(&this->IV_->data), BLOCK_SIZE);
                 break;
         }
@@ -221,6 +250,8 @@ Cipher::OperationMode Cipher::OperationMode::loadFromFile(const std::string& fil
                 case Identifier::ECB:
                     break;
                 case Identifier::CBC:
+                case Identifier::OFB:
+                case Identifier::CTR:
                     if(optmode_out.IV_ == nullptr) optmode_out.IV_ = new InitVector;
                     file.read(reinterpret_cast<char*>(optmode_out.IV_->data),BLOCK_SIZE);
                     if (!file || file.gcount() != BLOCK_SIZE) {
@@ -464,6 +495,26 @@ void Cipher::encrypt(const uint8_t*const data, size_t size, uint8_t*const output
                 handleExceptionCode(result, "CBC encryption");
             }
             break;
+        case OperationMode::Identifier::OFB:
+            {
+                const uint8_t* iv = this->config.getIVpointerData();
+                if (iv == nullptr) {
+                    throw EncryptionException("IV is required for OFB mode but not set");
+                }
+                result = encryptOFB(data, size, this->keyExpansion, keylenBits, iv, output);
+                handleExceptionCode(result, "OFB encryption");
+            }
+            break;
+        case OperationMode::Identifier::CTR:
+            {
+                const uint8_t* iv = this->config.getIVpointerData();
+                if (iv == nullptr) {
+                    throw EncryptionException("Counter is required for CTR mode but not set");
+                }
+                result = encryptCTR(data, size, this->keyExpansion, keylenBits, iv, output);
+                handleExceptionCode(result, "CTR encryption");
+            }
+            break;
         default:
             throw EncryptionException("Unsupported operation mode: " + std::to_string(static_cast<int>(opt_mode)));
     }
@@ -510,6 +561,26 @@ void Cipher::decrypt(const uint8_t*const data, size_t size, uint8_t*const output
                 }
                 result = decryptCBC(data, size, this->keyExpansion, key_len_bits, iv, output);
                 handleExceptionCode(result, "CBC decryption");
+            }
+            break;
+        case OperationMode::Identifier::OFB:
+            {
+                const uint8_t* iv = this->config.getIVpointerData();
+                if (iv == nullptr) {
+                    throw DecryptionException("IV is required for OFB mode but not set");
+                }
+                result = decryptOFB(data, size, this->keyExpansion, key_len_bits, iv, output);
+                handleExceptionCode(result, "OFB decryption");
+            }
+            break;
+        case OperationMode::Identifier::CTR:
+            {
+                const uint8_t* iv = this->config.getIVpointerData();
+                if (iv == nullptr) {
+                    throw DecryptionException("Counter is required for CTR mode but not set");
+                }
+                result = decryptCTR(data, size, this->keyExpansion, key_len_bits, iv, output);
+                handleExceptionCode(result, "CTR decryption");
             }
             break;
         default:

--- a/tests/unit/test_AES.cpp
+++ b/tests/unit/test_AES.cpp
@@ -19,7 +19,8 @@ CryptoTest::BlockCipher::TypeByteInterface<KeyExpansion_t, Block_t> byteInterfac
     [](const KeyExpansion_t*const input, size_t keySize,const uint8_t* bytes) -> bool{
         return compareKeyExpansionBytes(input, bytes);
     },
-    [](KeyExpansion_t*const output, size_t keylenbits, const unsigned char*const input) -> int{
+    [](KeyExpansion_t*const output, size_t keySize, const unsigned char*const input) -> int{
+        if(keySize != 128 && keySize != 192 && keySize != 256) return 1;
         return static_cast<int>(KeyExpansionReadFromBytes(output, input));
     },
     [](const Block_t*const input, const uint8_t* bytes) -> bool{

--- a/tests/unit/test_cipher.cpp
+++ b/tests/unit/test_cipher.cpp
@@ -31,7 +31,7 @@ bool runTestsForKeylengthMode(AESKEY_LENBITS ks, AESCIPHER_OPTMODE cm);
 int main() {
     std::cout << "=== C/C++ Cipher.hpp Tests with Specific Exception Handling ===" << std::endl;
     std::vector<AESKEY_LENBITS> keylengths = { AESKEY_LENBITS::_128, AESKEY_LENBITS::_192, AESKEY_LENBITS::_256 };
-    std::vector<AESCIPHER_OPTMODE> optModes = { AESCIPHER_OPTMODE::ECB, AESCIPHER_OPTMODE::CBC };
+    std::vector<AESCIPHER_OPTMODE> optModes = { AESCIPHER_OPTMODE::ECB, AESCIPHER_OPTMODE::CBC, AESCIPHER_OPTMODE::OFB, AESCIPHER_OPTMODE::CTR };
     bool success = true;
 
     for(AESKEY_LENBITS ks: keylengths){
@@ -64,6 +64,8 @@ bool test_successful_operations(AESKEY_LENBITS ks, AESCIPHER_OPTMODE cm) {
     switch(cm) {
         case AESCIPHER_OPTMODE::ECB: cm_ = TV::CipherMode::ECB; break;
         case AESCIPHER_OPTMODE::CBC: cm_ = TV::CipherMode::CBC; break;
+        case AESCIPHER_OPTMODE::OFB: cm_ = TV::CipherMode::OFB; break;
+        case AESCIPHER_OPTMODE::CTR: cm_ = TV::CipherMode::CTR; break;
         default:
             std::cerr << "Error: Unsupported operation cm." << std::endl;
             return false;
@@ -83,10 +85,10 @@ bool test_successful_operations(AESKEY_LENBITS ks, AESCIPHER_OPTMODE cm) {
         // Test operation cm
         AESKEY key(example->getKey(), ks);
         AESCIPHER ciph(key, AESCIPHER::OperationMode(cm));
-        ciph.setInitialVectorForTesting(std::vector<uint8_t>(
-            SP::kInitializationVector,
-            SP::kInitializationVector + 16
-        ));
+        const unsigned char* iv_data = (cm == AESCIPHER_OPTMODE::CTR)
+            ? SP::kInitialCounter
+            : SP::kInitializationVector;
+        ciph.setInitialVectorForTesting(std::vector<uint8_t>(iv_data, iv_data + 16));
 
         // Verify key expansion is initialized
         success &= ASSERT_TRUE(
@@ -306,6 +308,8 @@ bool runTestsForKeylengthMode(AESKEY_LENBITS ks, AESCIPHER_OPTMODE cm){
     switch(cm) {
         case AESCIPHER_OPTMODE::ECB: cm_ = TV::CipherMode::ECB; break;
         case AESCIPHER_OPTMODE::CBC: cm_ = TV::CipherMode::CBC; break;
+        case AESCIPHER_OPTMODE::OFB: cm_ = TV::CipherMode::OFB; break;
+        case AESCIPHER_OPTMODE::CTR: cm_ = TV::CipherMode::CTR; break;
         default: return false;
     }
 

--- a/tests/unit/test_operation_modes.cpp
+++ b/tests/unit/test_operation_modes.cpp
@@ -12,6 +12,8 @@ namespace SP = TestVectors::AES::SP800_38A;
 
 bool test_ecb_mode(TV::KeySize ks);
 bool test_cbc_mode(TV::KeySize ks);
+bool test_ofb_mode(TV::KeySize ks);
+bool test_ctr_mode(TV::KeySize ks);
 bool test_iv_independence(TV::KeySize ks);
 bool test_error_conditions(TV::KeySize ks);
 
@@ -128,6 +130,92 @@ bool test_cbc_mode(TV::KeySize ks) {
     return successStatus;
 }
 
+bool test_ofb_mode(TV::KeySize ks) {
+    TEST_SUITE("OFB Mode Tests");
+
+    bool successStatus = true;
+    SP::OFB::TestVector example_ofb(ks, TV::Direction::Encrypt);
+    const size_t expanded_key_len = getKeyExpansionLengthBytesfromKeylenBits(static_cast<KeylenBits_t>(ks));
+    std::vector<uint8_t> expanded_key(expanded_key_len);
+    uint8_t output[SP::kDataSize];
+    uint8_t decrypted[SP::kDataSize];
+
+    // Prepare key expansion
+    successStatus = ASSERT_TRUE(
+        KeyExpansionInitWrite(example_ofb.getKey().data(), static_cast<size_t>(ks), expanded_key.data(), false) == NoException,
+        "Key expansion should succeed"
+    ) && successStatus;
+
+    // Test OFB encryption
+    successStatus = ASSERT_TRUE(
+        encryptOFB(SP::kPlainText, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ofb.getIV().data(), output) == NoException,
+        "OFB encryption should succeed"
+    ) && successStatus;
+
+    successStatus = ASSERT_BYTES_EQUAL(
+        example_ofb.getExpectedOutput().data(), output, SP::kDataSize,
+        "OFB encryption should match test vector"
+    ) && successStatus;
+
+    // Test OFB decryption (round-trip)
+    successStatus = ASSERT_TRUE(
+        decryptOFB(output, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ofb.getIV().data(), decrypted) == NoException,
+        "OFB decryption should succeed"
+    ) && successStatus;
+
+    successStatus = ASSERT_BYTES_EQUAL(
+        SP::kPlainText, decrypted, SP::kDataSize,
+        "OFB roundtrip should preserve plaintext"
+    ) && successStatus;
+
+    PRINT_RESULTS();
+
+    return successStatus;
+}
+
+bool test_ctr_mode(TV::KeySize ks) {
+    TEST_SUITE("CTR Mode Tests");
+
+    bool successStatus = true;
+    SP::CTR::TestVector example_ctr(ks, TV::Direction::Encrypt);
+    const size_t expanded_key_len = getKeyExpansionLengthBytesfromKeylenBits(static_cast<KeylenBits_t>(ks));
+    std::vector<uint8_t> expanded_key(expanded_key_len);
+    uint8_t output[SP::kDataSize];
+    uint8_t decrypted[SP::kDataSize];
+
+    // Prepare key expansion
+    successStatus = ASSERT_TRUE(
+        KeyExpansionInitWrite(example_ctr.getKey().data(), static_cast<size_t>(ks), expanded_key.data(), false) == NoException,
+        "Key expansion should succeed"
+    ) && successStatus;
+
+    // Test CTR encryption
+    successStatus = ASSERT_TRUE(
+        encryptCTR(SP::kPlainText, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ctr.getCounter().data(), output) == NoException,
+        "CTR encryption should succeed"
+    ) && successStatus;
+
+    successStatus = ASSERT_BYTES_EQUAL(
+        example_ctr.getExpectedOutput().data(), output, SP::kDataSize,
+        "CTR encryption should match test vector"
+    ) && successStatus;
+
+    // Test CTR decryption (round-trip)
+    successStatus = ASSERT_TRUE(
+        decryptCTR(output, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ctr.getCounter().data(), decrypted) == NoException,
+        "CTR decryption should succeed"
+    ) && successStatus;
+
+    successStatus = ASSERT_BYTES_EQUAL(
+        SP::kPlainText, decrypted, SP::kDataSize,
+        "CTR roundtrip should preserve plaintext"
+    ) && successStatus;
+
+    PRINT_RESULTS();
+
+    return successStatus;
+}
+
 bool test_iv_independence(TV::KeySize ks) {
     TEST_SUITE("IV Independence Tests");
 
@@ -165,6 +253,8 @@ bool test_error_conditions(TV::KeySize ks) {
     bool successStatus = true;
     SP::ECB::TestVector example_ecb(ks, TV::Direction::Encrypt);
     SP::CBC::TestVector example_cbc(ks, TV::Direction::Encrypt);
+    SP::OFB::TestVector example_ofb(ks, TV::Direction::Encrypt);
+    SP::CTR::TestVector example_ctr(ks, TV::Direction::Encrypt);
     const size_t expanded_key_len = getKeyExpansionLengthBytesfromKeylenBits(static_cast<KeylenBits_t>(ks));
     std::vector<uint8_t> expanded_key(expanded_key_len);
     uint8_t output[SP::kDataSize];
@@ -208,6 +298,46 @@ bool test_error_conditions(TV::KeySize ks) {
         "CBC should handle zero length"
     ) && successStatus;
 
+    successStatus = ASSERT_TRUE(
+        encryptOFB(NULL, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ofb.getIV().data(), output) == NullInput,
+        "OFB should handle null input"
+    ) && successStatus;
+
+    successStatus = ASSERT_TRUE(
+        encryptOFB(SP::kPlainText, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ofb.getIV().data(), NULL) == NullOutput,
+        "OFB should handle null output"
+    ) && successStatus;
+
+    successStatus = ASSERT_TRUE(
+        encryptOFB(SP::kPlainText, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), NULL, output) == NullInitialVector,
+        "OFB should handle null IV"
+    ) && successStatus;
+
+    successStatus = ASSERT_TRUE(
+        encryptOFB(SP::kPlainText, 0, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ofb.getIV().data(), output) == ZeroLength,
+        "OFB should handle zero length"
+    ) && successStatus;
+
+    successStatus = ASSERT_TRUE(
+        encryptCTR(NULL, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ctr.getCounter().data(), output) == NullInput,
+        "CTR should handle null input"
+    ) && successStatus;
+
+    successStatus = ASSERT_TRUE(
+        encryptCTR(SP::kPlainText, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ctr.getCounter().data(), NULL) == NullOutput,
+        "CTR should handle null output"
+    ) && successStatus;
+
+    successStatus = ASSERT_TRUE(
+        encryptCTR(SP::kPlainText, SP::kDataSize, expanded_key.data(), static_cast<KeylenBits_t>(ks), NULL, output) == NullInitialVector,
+        "CTR should handle null counter"
+    ) && successStatus;
+
+    successStatus = ASSERT_TRUE(
+        encryptCTR(SP::kPlainText, 0, expanded_key.data(), static_cast<KeylenBits_t>(ks), example_ctr.getCounter().data(), output) == ZeroLength,
+        "CTR should handle zero length"
+    ) && successStatus;
+
     PRINT_RESULTS();
 
     return successStatus;
@@ -222,6 +352,8 @@ bool runTestsForKeylength(TV::KeySize ks) {
 
     successStatus = test_ecb_mode(ks) && successStatus;
     successStatus = test_cbc_mode(ks) && successStatus;
+    successStatus = test_ofb_mode(ks) && successStatus;
+    successStatus = test_ctr_mode(ks) && successStatus;
     successStatus = test_iv_independence(ks) && successStatus;
     successStatus = test_error_conditions(ks) && successStatus;
 


### PR DESCRIPTION
# Add OFB and CTR operation mode support

  This PR extends the AES cipher implementation with support for Output Feedback (OFB) and Counter (CTR) operation modes,  completing the set of stream cipher modes alongside the existing ECB and CBC block cipher modes.

## Changes

### Core implementation (src/core/cipher.cpp, include/cipher.hpp)
- Added OFB and CTR to the OperationMode::Identifier enum
- Implemented IV initialization for OFB and CTR modes using a time-based entropy source (same strategy as CBC)
- Wired encryptOFB, decryptOFB, encryptCTR, and decryptCTR into the Cipher::encrypt / Cipher::decrypt dispatch
- Added string serialization/deserialization ("OFB", "CTR") and IV persistence (save/load from file)

### C layer (data-encryption/include/operation_modes.h, data-encryption/src/)
- Added full Doxygen documentation for encryptOFB, decryptOFB, encryptCTR, and decryptCTR
- Fixed a missing BlockDestroy call in encryptCTR__ (memory leak)
- Fixed an incorrect comparison between a KeyExpansion object and a byte array in key_expansion.c
- Added a guard against invalid key sizes

### Tests (tests/unit/)
- Extended test_cipher.cpp and test_operation_modes.cpp with OFB and CTR round-trip and edge-case tests

## Notes

- Both OFB and CTR are stream cipher modes: they do not require input sizes to be multiples of 16 bytes (unlike ECB and CBC)
- OFB and CTR encryption and decryption are symmetric (same keystream XOR'd in both directions)
- The CTR counter is incremented as a 64-bit little-endian integer per block