### PR TITLE
Refactor/makefiles

### DIFF
--- a/command-line-tools/Makefile
+++ b/command-line-tools/Makefile
@@ -24,7 +24,7 @@ LDFLAGS += -L$(PROJECT_ROOT)/lib
 LIBS = -lcryptocli -lfilehandlers -laesencryption_cpp  -laesencryption_c  -lmetricsanalysis
 
 # Define required dependencies (library files)
-REQUIRED_DEPS = \
+DEPS = \
     $(PROJECT_ROOT)/lib/libaesencryption_c.a \
     $(PROJECT_ROOT)/lib/libaesencryption_cpp.a \
     $(PROJECT_ROOT)/lib/libfilehandlers.a \
@@ -78,7 +78,7 @@ clean:
 	@rm -f $(BINARIES)
 	$(call print_success,"Cleaned command-line-tools module")
 
-.PHONY: clean
+.PHONY: all clean check-deps dependencies
 
 # Dependency inclusion
 $(eval $(include_deps))

--- a/config.mk
+++ b/config.mk
@@ -40,10 +40,10 @@ NO_OPTIMIZE = -O0
 OPTIMIZE = -O2
 
 # Coverage analysis support
-COVERAGE_FLAGS = --coverage -fprofile-arcs -ftest-coverage
+COVERAGE_FLAGS = --coverage -fprofile-abs-path
 
-# Default build type (debug-oriented)
-BUILD_TYPE ?= debug
+# Default build type
+BUILD_TYPE ?= test
 
 # Build type specific flags
 ifeq ($(BUILD_TYPE),debug)

--- a/crypto-cli/Makefile
+++ b/crypto-cli/Makefile
@@ -16,10 +16,10 @@ SOURCES = $(wildcard $(SRCDIR)/*.cpp)
 OBJECTS = $(SOURCES:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
 
 # Local includes (in addition to common includes)
-INCLUDES = -I./$(INCDIR) -I$(PROJECT_ROOT)/$(INCDIR)
+INCLUDES = -I$(PROJECT_ROOT)/crypto-cli/$(INCDIR) -I$(PROJECT_ROOT)/$(INCDIR)
 
 # Dependencies on other modules
-DEPS =$(LIBDIR)/libaesencryption_cpp.a
+DEPS = $(LIBDIR)/libaesencryption_cpp.a
 
 # External libraries needed
 LIBS = -L$(LIBDIR) -laesencryption_cpp
@@ -33,7 +33,7 @@ check-deps:
 
 # Build dependencies (optional - for convenience)
 dependencies:
-# 	$(call print_info,"Building project dependencies...")
+	$(call print_info,"Building project dependencies...")
 	@$(MAKE) -C $(PROJECT_ROOT)/src
 	$(call print_success,"All dependencies built successfully")
 
@@ -60,4 +60,4 @@ clean:
 $(eval $(include_deps))
 
 # Module-specific targets
-.PHONY: check-deps setup-test-data
+.PHONY: all clean check-deps dependencies

--- a/data-encryption/Makefile
+++ b/data-encryption/Makefile
@@ -9,20 +9,24 @@ LIBDIR = $(PROJECT_ROOT)/lib
 TARGET_LIB = $(LIBDIR)/libaesencryption_c.a
 
 # Local source directory and object directory
-OBJDIR = $(PROJECT_ROOT)/obj/data-encryption
+OBJDIR = $(PROJECT_ROOT)/obj/$(notdir $(CURDIR))
 
 # Local includes (private headers)
-INCLUDES = -I$(INCDIR)
+INCLUDES = -I$(PROJECT_ROOT)/data-encryption/$(INCDIR)
 
 # Source files and objects
 SOURCES = $(wildcard $(SRCDIR)/*.c)
 OBJECTS = $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
 
+# Static analysis with cppcheck
+CPPCHECK = cppcheck
+CPPCHECK_FLAGS = --check-level=exhaustive
+
 # Default target
 all: $(TARGET_LIB)
 
 # Static library creation
-$(TARGET_LIB): $(OBJECTS) | $(OBJDIR) $(LIBDIR)
+$(TARGET_LIB): $(OBJECTS) | $(LIBDIR) $(OBJDIR)
 	$(call create_static_lib,$@,$(OBJECTS))
 
 # Compilation rule for C files
@@ -44,9 +48,9 @@ analyze: $(TARGET_LIB)
 	$(call print_info,"Running static analysis on C code...")
 	@if command -v $(CPPCHECK) >/dev/null 2>&1; then \
 		$(CPPCHECK) $(CPPCHECK_FLAGS) --language=c $(SRCDIR)/; \
-		$(call print_success,"Static analysis completed"); \
+		echo -e "$(COLOR_GREEN)[SUCCESS]$(COLOR_NC) Static analysis completed"; \
 	else \
-		$(call print_warning,"$(CPPCHECK) not found, skipping analysis"); \
+		echo -e "$(COLOR_YELLOW)[WARNING]$(COLOR_NC) $(CPPCHECK) not found - skipping analysis"; \
 	fi
 
 # Show library information
@@ -60,4 +64,4 @@ info: $(TARGET_LIB)
 $(eval $(include_deps))
 
 # Additional phony targets
-.PHONY: test analyze test-memory info
+.PHONY: all clean analyze info

--- a/data-encryption/src/key_expansion.c
+++ b/data-encryption/src/key_expansion.c
@@ -18,7 +18,10 @@ static KeyExpansion_t* KeyExpansionAllocate(enum Nk_t Nk){
   output->wordsSize = getKeyExpansionLengthWordsfromNk(Nk);
   output->blockSize = getKeyExpansionLengthBlocksfromNk(Nk);
   output->dataBlocks = (Block_t*)malloc(output->blockSize*sizeof(Block_t));
-  if(output->dataBlocks == NULL) return NULL;
+  if(output->dataBlocks == NULL) {
+      KeyExpansionDestroy(&output);
+      return NULL;
+  }
   return output;
 }
 

--- a/file-handlers/Makefile
+++ b/file-handlers/Makefile
@@ -16,13 +16,13 @@ SOURCES = $(wildcard $(SRCDIR)/*.cpp)
 OBJECTS = $(SOURCES:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
 
 # Local includes (in addition to common includes)
-INCLUDES = -I./$(INCDIR) -I../$(INCDIR) -I../metrics-analysis/$(INCDIR)
+INCLUDES = -I$(PROJECT_ROOT)/file-handlers/$(INCDIR) -I$(PROJECT_ROOT)/$(INCDIR) -I$(PROJECT_ROOT)/metrics-analysis/$(INCDIR)
 
 # Dependencies on other modules
 DEPS = $(LIBDIR)/libaesencryption_cpp.a $(LIBDIR)/libmetricsanalysis.a
 
 # External libraries needed
-LIBS = -L$(LIBDIR) -laesencryption_cpp lmetricsanalysis
+LIBS = -L$(LIBDIR) -laesencryption_cpp -lmetricsanalysis
 
 # Default target
 all: $(TARGET_LIB)
@@ -68,7 +68,7 @@ setup-test-data:
 $(eval $(include_deps))
 
 # Module-specific targets
-.PHONY: check-deps setup-test-data
+.PHONY: all clean check-deps dependencies setup-test-data list-formats
 
 # List supported file formats
 list-formats:

--- a/file-handlers/Makefile
+++ b/file-handlers/Makefile
@@ -72,11 +72,11 @@ $(eval $(include_deps))
 
 # List supported file formats
 list-formats:
-	@echo "$(COLOR_BLUE)Supported file formats:$(COLOR_NC)"
-	@echo "  - Text files (.txt)"
-	@echo "  - Bitmap images (.bmp)"
-	@echo "  - Binary files (generic)"
-	@echo "$(COLOR_YELLOW)Planned formats:$(COLOR_NC)"
-	@echo "  - PNG images"
-	@echo "  - JPEG images"
-	@echo "  - Custom binary formats"
+	@echo -e "$(COLOR_BLUE)Supported file formats:$(COLOR_NC)"
+	@echo -e "  - Text files (.txt)"
+	@echo -e "  - Bitmap images (.bmp)"
+	@echo -e "  - Binary files (generic)"
+	@echo -e "$(COLOR_YELLOW)Planned formats:$(COLOR_NC)"
+	@echo -e "  - PNG images"
+	@echo -e "  - JPEG images"
+	@echo -e "  - Custom binary formats"

--- a/metrics-analysis/Makefile
+++ b/metrics-analysis/Makefile
@@ -12,14 +12,11 @@ TARGET_LIB = $(LIBDIR)/libmetricsanalysis.a
 OBJDIR = $(PROJECT_ROOT)/obj/$(notdir $(CURDIR))
 
 # Local includes
-INCLUDES = -I$(INCDIR)
+INCLUDES = -I$(PROJECT_ROOT)/metrics-analysis/$(INCDIR)
 
 # Source files
 SOURCES = $(wildcard $(SRCDIR)/*.cpp)
 OBJECTS = $(SOURCES:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
-
-# Dependencies on other modules
-DEPS =
 
 # Default target
 all: $(TARGET_LIB)
@@ -44,3 +41,5 @@ clean:
 
 # Dependency inclusion
 $(eval $(include_deps))
+
+.PHONY: all clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,11 +16,8 @@ OBJDIR = $(PROJECT_ROOT)/obj/$(notdir $(CURDIR))
 INCLUDES = -I./utils/ -I$(PROJECT_ROOT)/data-encryption/include -I$(PROJECT_ROOT)/include
 
 # Source files
-SOURCES = $(call find_sources,$(SRCDIR),cpp)
-#$(info SOURCES=$(SOURCES))
-# Object files
-OBJECTS = $(call sources_to_objects,$(SOURCES),$(OBJDIR),cpp)
-#$(info OBJECTS=$(OBJECTS))
+SOURCES = $(wildcard $(SRCDIR)/*.cpp)
+OBJECTS = $(SOURCES:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
 
 # Dependencies on other modules
 DEPS = $(LIBDIR)/libaesencryption_c.a
@@ -41,7 +38,7 @@ dependencies:
 	$(call print_success,"All dependencies built successfully")
 
 # Library target
-$(TARGET_LIB): check-deps $(OBJECTS) | $(OBJDIR) $(LIBDIR)
+$(TARGET_LIB): check-deps $(OBJECTS) | $(LIBDIR) $(OBJDIR)
 	$(call create_static_lib,$@,$(OBJECTS))
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.cpp | $(OBJDIR)
@@ -53,7 +50,7 @@ $(OBJDIR) $(LIBDIR):
 
 # Clean target
 clean:
-	$(call clean_dir,$(OBJDIR))
+	$(call clean_standard)
 	@rm -f $(TARGET_LIB)
 	$(call print_success,"Cleaned core C++ module: $(MODULE_NAME)")
 
@@ -64,3 +61,5 @@ check-symbols: $(TARGET_LIB)
 
 # Dependency inclusion
 $(eval $(include_deps))
+
+.PHONY: all clean check-deps dependencies check-symbols

--- a/test-framework/Makefile
+++ b/test-framework/Makefile
@@ -1,5 +1,6 @@
 # test-framework/Makefile - NIST AES test vectors library
 include ../common.mk
+BUILD_TYPE ?= test
 include ../config.mk
 
 # Module configuration

--- a/test-framework/Makefile
+++ b/test-framework/Makefile
@@ -9,10 +9,10 @@ LIBDIR = $(PROJECT_ROOT)/lib
 TARGET_LIB = $(LIBDIR)/libtest_vectors.a
 
 # Local source directory and object directory
-OBJDIR = $(PROJECT_ROOT)/obj/test-framework
+OBJDIR = $(PROJECT_ROOT)/obj/$(notdir $(CURDIR))
 
 # Local includes (private headers)
-INCLUDES = -I$(INCDIR) -I$(INCDIR)/test-vectors
+INCLUDES = -I$(PROJECT_ROOT)/test-framework/$(INCDIR) -I$(PROJECT_ROOT)/test-framework/$(INCDIR)/test-vectors
 
 # Source files and objects
 SOURCES = $(wildcard $(SRCDIR)/test-vectors/*.cpp)
@@ -22,7 +22,7 @@ OBJECTS = $(call sources_to_objects,$(SOURCES),$(OBJDIR),cpp)
 all: $(TARGET_LIB)
 
 # Static library creation
-$(TARGET_LIB): $(OBJECTS) | $(OBJDIR) $(LIBDIR)
+$(TARGET_LIB): $(OBJECTS) | $(LIBDIR) $(OBJDIR)
 	$(call create_static_lib,$@,$(OBJECTS))
 
 # Compilation rule for C++ files

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,13 @@
 # Include common functions and utilities
 include ../common.mk
+BUILD_TYPE ?= test
 include ../config.mk
 
 # Local configuration
 MODULE_NAME = $(notdir $(CURDIR))
 PROJECT_ROOT := $(call find-project-root)
+OBJDIR = $(PROJECT_ROOT)/obj/$(notdir $(CURDIR))
+BINDIR = $(PROJECT_ROOT)/bin/$(notdir $(CURDIR))
 MODULE_DIRECTORIES := $(shell find . -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n 1 basename)
 
 MAKEFILE_DEBUG =? FALSE
@@ -188,7 +191,7 @@ define run_tests
 for test in $($(1)_TESTS); do \
 	if [ -f "$$test" ]; then \
 		$(call echo_building,"Executing: $$test"); \
-		if ./$$test; then \
+		if $$test; then \
 			$(call echo_success,"PASSED: $$test"); \
 		else \
 			$(call echo_error,"FAILED: $$test"); \


### PR DESCRIPTION
## Summary

This branch refactors the build system across all modules to enforce consistency, then corrects the default build flags for the test modules.

## Makefile uniformity (all production modules)
- Standardise OBJDIR and INCLUDES to use absolute $(PROJECT_ROOT)/… paths, eliminating reliance on the current working directory
- Fix prerequisite order (| $(LIBDIR) $(OBJDIR) → | $(LIBDIR) $(OBJDIR) — lib before obj to match dependency order)
- Expand .PHONY declarations to cover all non-file targets (all, clean, check-deps, dependencies, …)
- Rename REQUIRED_DEPS → DEPS in command-line-tools for consistency with other modules
- Fix missing -l flag for lmetricsanalysis in file-handlers
- Add -e flag to echo calls in file-handlers and data-encryption so escape sequences render correctly
- Simplify src/Makefile source/object expansion to use plain wildcard + pattern substitution

## Test module build flags
- Add BUILD_TYPE ?= test to both test-framework/Makefile and tests/Makefile, placed before include ../config.mk so it takes precedence over the global default
- Add explicit OBJDIR and BINDIR to tests/Makefile ($(PROJECT_ROOT)/obj/tests and $(PROJECT_ROOT)/bin/tests), matching the pattern already used by command-line-tools
- Update config.mk: replace -fprofile-arcs -ftest-coverage with -fprofile-abs-path in COVERAGE_FLAGS, and change the global BUILD_TYPE default from debug to test

## Bug fix
- data-encryption/src/key_expansion.c: call KeyExpansionDestroy before returning NULL when dataBlocks allocation fails, preventing a memory leak of the partially-initialised KeyExpansion_t struct