### PR TITLE
Refactor/cli tools

### DIFF
--- a/command-line-tools/hsm-encrypt/hsm_encrypt.cpp
+++ b/command-line-tools/hsm-encrypt/hsm_encrypt.cpp
@@ -4,6 +4,7 @@
 #include "../../include/cipher.hpp"
 #include "../../include/key.hpp"
 #include "../../file-handlers/include/file_base.hpp"
+#include "../../crypto-cli/include/cli_config.hpp"
 
 #include <iostream>
 #include <string>
@@ -17,25 +18,6 @@ using namespace AESencryption;
 using namespace AESencryption::HSM;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-static void print_usage(const char* prog) {
-    std::cerr
-        << "Usage: " << prog << " [options]\n"
-        << "\nRequired:\n"
-        << "  --lib    PATH    PKCS#11 library path\n"
-        << "                   e.g. /usr/lib64/pkcs11/libsofthsm2.so\n"
-        << "  --token  LABEL   Token label\n"
-        << "  --pin    PIN     User PIN\n"
-        << "  --mode   MODE    Operation mode: ecb | cbc | ctr\n"
-        << "  --keybits N      Key length in bits: 128 | 192 | 256\n"
-        << "  --key    LABEL   Key label in the HSM\n"
-        << "  --input  FILE    Input file path\n"
-        << "  --output FILE    Output file path\n"
-        << "\nOptional:\n"
-        << "  --decrypt        Decrypt instead of encrypt (default: encrypt)\n"
-        << "  --iv     HEX     16-byte IV as 32 hex characters (CBC/CTR)\n"
-        << "                   If omitted, a random IV is generated and printed\n";
-}
 
 static Cipher::OperationMode::Identifier parse_mode(const std::string& s) {
     if (s == "ecb") return Cipher::OperationMode::Identifier::ECB;
@@ -65,6 +47,89 @@ static std::vector<uint8_t> parse_hex_iv(const std::string& hex) {
     return iv;
 }
 
+// ── HSMCryptoConfig ───────────────────────────────────────────────────────────
+
+class HSMCryptoConfig : public CLIConfig::BaseCryptoConfig {
+public:
+    bool validate(const CLIConfig::ArgumentParser& parser) override;
+    void print_help(const CLIConfig::ArgumentParser& parser) const;
+
+    std::string lib_path, token, pin, key_label, input_file, output_file;
+    std::string iv_hex;
+    bool        decrypt        = false;
+    Cipher::OperationMode::Identifier operation_mode = Cipher::OperationMode::Identifier::CBC;
+    Key::LengthBits                   key_length     = Key::LengthBits::_128;
+};
+
+bool HSMCryptoConfig::validate(const CLIConfig::ArgumentParser& parser) {
+    lib_path    = parser.getOr("--lib",     "");
+    token       = parser.getOr("--token",   "");
+    pin         = parser.getOr("--pin",     "");
+    key_label   = parser.getOr("--key",     "");
+    input_file  = parser.getOr("--input",   "");
+    output_file = parser.getOr("--output",  "");
+    iv_hex      = parser.getOr("--iv",      "");
+    decrypt     = parser.has("--decrypt");
+
+    // Check required fields
+    for (auto& [name, val] : std::vector<std::pair<std::string, std::string>>{
+            {"--lib",     lib_path},  {"--token",   token},
+            {"--pin",     pin},       {"--key",     key_label},
+            {"--input",   input_file},{"--output",  output_file}}) {
+        if (val.empty()) {
+            error_message = "Missing required argument: " + name;
+            is_valid = false;
+            return false;
+        }
+    }
+
+    std::string mode_str    = parser.getOr("--mode",    "");
+    std::string keybits_str = parser.getOr("--keybits", "");
+
+    if (mode_str.empty()) {
+        error_message = "Missing required argument: --mode";
+        is_valid = false;
+        return false;
+    }
+    if (keybits_str.empty()) {
+        error_message = "Missing required argument: --keybits";
+        is_valid = false;
+        return false;
+    }
+
+    try {
+        operation_mode = parse_mode(mode_str);
+        key_length     = parse_keybits(keybits_str);
+    } catch (const std::exception& e) {
+        error_message = e.what();
+        is_valid = false;
+        return false;
+    }
+
+    is_valid = true;
+    return true;
+}
+
+void HSMCryptoConfig::print_help(const CLIConfig::ArgumentParser& parser) const {
+    const char* prog = parser.program_name();
+    std::cerr
+        << "Usage: " << prog << " [options]\n"
+        << "\nRequired:\n"
+        << "  --lib    PATH    PKCS#11 library path\n"
+        << "                   e.g. /usr/lib64/pkcs11/libsofthsm2.so\n"
+        << "  --token  LABEL   Token label\n"
+        << "  --pin    PIN     User PIN\n"
+        << "  --mode   MODE    Operation mode: ecb | cbc | ctr\n"
+        << "  --keybits N      Key length in bits: 128 | 192 | 256\n"
+        << "  --key    LABEL   Key label in the HSM\n"
+        << "  --input  FILE    Input file path\n"
+        << "  --output FILE    Output file path\n"
+        << "\nOptional:\n"
+        << "  --decrypt        Decrypt instead of encrypt (default: encrypt)\n"
+        << "  --iv     HEX     16-byte IV as 32 hex characters (CBC/CTR)\n"
+        << "                   If omitted, a random IV is generated and printed\n";
+}
+
 static std::string bytes_to_hex(const std::vector<uint8_t>& bytes) {
     std::ostringstream oss;
     for (auto b : bytes)
@@ -80,69 +145,37 @@ static bool mode_needs_iv(Cipher::OperationMode::Identifier m) {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 int main(int argc, const char* argv[]) {
-    if (argc < 2) { print_usage(argv[0]); return 1; }
-
-    std::string lib_path, token_label, pin, mode_str, keybits_str,
-                key_label, input_path, output_path, iv_hex;
-    bool decrypt = false;
-
-    for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
-        auto next = [&]() -> std::string {
-            if (i + 1 >= argc)
-                throw std::invalid_argument("Missing value for " + arg);
-            return argv[++i];
-        };
-        if      (arg == "--lib")     lib_path     = next();
-        else if (arg == "--token")   token_label  = next();
-        else if (arg == "--pin")     pin          = next();
-        else if (arg == "--mode")    mode_str     = next();
-        else if (arg == "--keybits") keybits_str  = next();
-        else if (arg == "--key")     key_label    = next();
-        else if (arg == "--input")   input_path   = next();
-        else if (arg == "--output")  output_path  = next();
-        else if (arg == "--iv")      iv_hex       = next();
-        else if (arg == "--decrypt") decrypt      = true;
-        else { std::cerr << "Unknown argument: " << arg << "\n"; return 1; }
-    }
-
-    // Validate required arguments.
-    for (auto& [name, val] : std::vector<std::pair<std::string,std::string>>{
-            {"--lib",    lib_path},    {"--token",   token_label},
-            {"--pin",    pin},         {"--mode",    mode_str},
-            {"--keybits",keybits_str}, {"--key",     key_label},
-            {"--input",  input_path},  {"--output",  output_path}}) {
-        if (val.empty()) {
-            std::cerr << "Missing required argument: " << name << "\n";
-            print_usage(argv[0]);
-            return 1;
-        }
+    CLIConfig::ArgumentParser parser(argc, argv);
+    parser.parse();
+    HSMCryptoConfig config;
+    config.validate(parser);
+    if (!config.is_valid) {
+        std::cerr << config.error_message << "\n";
+        config.print_help(parser);
+        return 1;
     }
 
     try {
-        auto mode     = parse_mode(mode_str);
-        auto keybits  = parse_keybits(keybits_str);
-
         // ── Session & cipher setup ────────────────────────────────────────────
-        HSMSession session(lib_path, token_label, pin);
-        HSMCipher  cipher(session, mode);
+        HSMSession session(config.lib_path, config.token, config.pin);
+        HSMCipher  cipher(session, config.operation_mode);
 
         // ── Key: reuse existing or generate new ───────────────────────────────
         HSMKeyHandle key;
         try {
-            key = cipher.findKey(key_label);
-            std::cout << "Using existing HSM key: " << key_label << "\n";
+            key = cipher.findKey(config.key_label);
+            std::cout << "Using existing HSM key: " << config.key_label << "\n";
         } catch (const std::runtime_error&) {
-            key = cipher.generateKey(keybits, key_label);
-            std::cout << "Generated new HSM key:  " << key_label << "\n";
+            key = cipher.generateKey(config.key_length, config.key_label);
+            std::cout << "Generated new HSM key:  " << config.key_label << "\n";
         }
         cipher.setActiveKey(key);
 
         // ── IV handling ───────────────────────────────────────────────────────
-        if (mode_needs_iv(mode)) {
+        if (mode_needs_iv(config.operation_mode)) {
             std::vector<uint8_t> iv;
-            if (!iv_hex.empty()) {
-                iv = parse_hex_iv(iv_hex);
+            if (!config.iv_hex.empty()) {
+                iv = parse_hex_iv(config.iv_hex);
             } else {
                 // Generate a random IV via the HSM's RNG.
                 iv.resize(16);
@@ -158,20 +191,20 @@ int main(int argc, const char* argv[]) {
         }
 
         // ── File I/O via FileBase ─────────────────────────────────────────────
-        File::FileBase file(input_path);
+        File::FileBase file(config.input_file);
         file.load();
 
-        if (decrypt) {
+        if (config.decrypt) {
             file.apply_decryption(cipher);
-            std::cout << "Decrypted: " << input_path
-                      << " -> " << output_path << "\n";
+            std::cout << "Decrypted: " << config.input_file
+                      << " -> " << config.output_file << "\n";
         } else {
             file.apply_encryption(cipher);
-            std::cout << "Encrypted: " << input_path
-                      << " -> " << output_path << "\n";
+            std::cout << "Encrypted: " << config.input_file
+                      << " -> " << config.output_file << "\n";
         }
 
-        file.save(output_path);
+        file.save(config.output_file);
 
     } catch (const PKCS11Exception& e) {
         std::cerr << "[PKCS#11 error] " << e.what() << "\n";

--- a/command-line-tools/image-encryption/bmp_encryptor.cpp
+++ b/command-line-tools/image-encryption/bmp_encryptor.cpp
@@ -10,6 +10,44 @@ using namespace AESencryption;
 using namespace CLIConfig;
 using namespace File;
 
+class BmpCryptoConfig : public CLIConfig::FileCryptoConfig {
+public:
+    bool validate(const CLIConfig::ArgumentParser& parser) override {
+        if (!FileCryptoConfig::validate(parser)) return false;
+        show_metrics = parser.has("--show-metrics");
+        if (show_metrics) {
+            if (input_file.empty()) {
+                error_message = "Input file is required";
+                is_valid = false;
+                return false;
+            }
+            if (output_file.empty()) {
+                error_message = "Output file is required";
+                is_valid = false;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void print_help(const CLIConfig::ArgumentParser& parser) const override {
+        const char* prog = parser.program_name();
+        std::cout << prog << ". AES Encryption Tool\n\n"
+                  << "Usage:\n"
+                  << "\tEncryption\t"   << prog << " --encrypt --key <keyfile> --input <file> --output <file> [options]\n"
+                  << "\tDecryption\t"   << prog << " --decrypt --key <keyfile> --input <file> --output <file> --mode-data <file> [options]\n"
+                  << "\tKey Generation:\t" << prog << " --generate-key --key-length <bits> --output <file>\n\n"
+                  << "Options:\n"
+                  << "\t--key-length <bits>      Key length: 128, 192, or 256 (default: 128)\n"
+                  << "\t--mode <ECB|CBC|OFB|CTR> Operation mode (default: CBC)\n"
+                  << "\t--mode-data <file>       Required data for specific operation mode\n"
+                  << "\t--show-metrics           Show statistical metrics from input and output\n"
+                  << "\t--help                   Show this help message\n";
+    }
+
+    bool show_metrics = false;
+};
+
 int main(int argc, const char* argv[]){
     // Parsing arguments. Converting user intput to valid arguments for this program.
     ArgumentParser parser(argc, argv);

--- a/command-line-tools/image-encryption/bmp_encryptor.cpp
+++ b/command-line-tools/image-encryption/bmp_encryptor.cpp
@@ -12,15 +12,18 @@ using namespace File;
 
 int main(int argc, const char* argv[]){
     // Parsing arguments. Converting user intput to valid arguments for this program.
-    const CryptoConfig cryp_conf= ArgumentParser(argc,argv).parse();
+    ArgumentParser parser(argc, argv);
+    parser.parse();
+    BmpCryptoConfig cryp_conf;
+    cryp_conf.validate(parser);
     if(!cryp_conf.is_valid){
         std::cerr << cryp_conf.error_message;
         return 1;
     }
 
     try{
-        if(cryp_conf.operation == CryptoConfig::Operation::ENCRYPT
-            || cryp_conf.operation == CryptoConfig::Operation::DECRYPT){
+        if(cryp_conf.operation == BmpCryptoConfig::Operation::ENCRYPT
+            || cryp_conf.operation == BmpCryptoConfig::Operation::DECRYPT){
             Bitmap bmp(cryp_conf.input_file);
             Cipher::OperationMode optmode = cryp_conf.create_optmode();
             Cipher cipher(cryp_conf.create_key(), optmode);
@@ -31,8 +34,8 @@ int main(int argc, const char* argv[]){
             if(cryp_conf.show_metrics){
                 input_rand = std::make_unique<DataRandomness>(bmp.calculate_randomness());
             }
-            if(cryp_conf.operation == CryptoConfig::Operation::ENCRYPT) bmp.apply_encryption(cipher);
-            if(cryp_conf.operation == CryptoConfig::Operation::DECRYPT) bmp.apply_decryption(cipher);
+            if(cryp_conf.operation == BmpCryptoConfig::Operation::ENCRYPT) bmp.apply_encryption(cipher);
+            if(cryp_conf.operation == BmpCryptoConfig::Operation::DECRYPT) bmp.apply_decryption(cipher);
             if(cryp_conf.show_metrics){
                 output_rand = std::make_unique<DataRandomness>(bmp.calculate_randomness());
                 output_metrics_results(*input_rand, *output_rand);
@@ -45,7 +48,7 @@ int main(int argc, const char* argv[]){
             // Return with success status
             return 0;
         }
-        if(cryp_conf.operation == CryptoConfig::Operation::GENERATE_KEY){
+        if(cryp_conf.operation == BmpCryptoConfig::Operation::GENERATE_KEY){
             Key key(cryp_conf.key_length);
             key.save(cryp_conf.output_file.c_str());
             return 0;

--- a/crypto-cli/include/cli_config.hpp
+++ b/crypto-cli/include/cli_config.hpp
@@ -38,13 +38,13 @@ public:
     std::string error_message;
 };
 
-// Concrete config for the BMP/AES encryptor tool.
-class BmpCryptoConfig : public BaseCryptoConfig {
+// Concrete config for generic file encryption tools.
+class FileCryptoConfig : public BaseCryptoConfig {
 public:
     enum class Operation { ENCRYPT, DECRYPT, GENERATE_KEY };
 
     bool validate(const ArgumentParser& parser) override;
-    void print_help(const ArgumentParser& parser) const;
+    virtual void print_help(const ArgumentParser& parser) const;
 
     // Factory methods
     AESencryption::Key                           create_key()     const;
@@ -55,7 +55,6 @@ public:
     std::filesystem::path                            key_file, input_file, output_file, mode_file;
     AESencryption::Key::LengthBits                   key_length     = AESencryption::Key::LengthBits::_128;
     AESencryption::Cipher::OperationMode::Identifier operation_mode = AESencryption::Cipher::OperationMode::Identifier::CBC;
-    bool                                             show_metrics   = false;
 };
 
 } // namespace CLIConfig

--- a/crypto-cli/include/cli_config.hpp
+++ b/crypto-cli/include/cli_config.hpp
@@ -3,58 +3,59 @@
 #define CLI_CONFIG_HPP
 
 #include "../../include/cipher.hpp"
-#include <filesystem> // For path handling
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
 
 namespace CLIConfig {
 
-// Configuration structure - the integration point
-struct CryptoConfig {
-    enum class Operation {
-        ENCRYPT,
-        DECRYPT,
-        GENERATE_KEY
-    };
+// Dumb tokenizer: walks argv and populates a key→value map.
+// No crypto-specific knowledge.
+class ArgumentParser {
+public:
+    ArgumentParser(int argc, const char** argv);
+    void parse();
 
-    Operation operation;
-    std::filesystem::path key_file;
-    std::filesystem::path input_file;
-    std::filesystem::path output_file;
-    std::filesystem::path mode_file; // File containing necessary data for the operation mode
+    bool        has(const std::string& flag) const;
+    std::string get(const std::string& flag) const;   // throws std::out_of_range if absent
+    std::string getOr(const std::string& flag, const std::string& fallback) const;
+    const char* program_name() const;
 
-    // Optional parameters with defaults
-    AESencryption::Key::LengthBits key_length = AESencryption::Key::LengthBits::_128;
-    AESencryption::Cipher::OperationMode::Identifier operation_mode = AESencryption::Cipher::OperationMode::Identifier::CBC;
-    bool show_metrics = false;
-
-    // Validation flags
-    bool is_valid = false;
-    std::string error_message;
-
-    // Validation method
-    bool validate();
-
-    // Convert to crypto objects - the integration point
-    // Consider: Throws std::runtime_error
-    AESencryption::Key create_key() const;
-    AESencryption::Cipher::OperationMode create_optmode() const;
+private:
+    int          argc_;
+    const char** argv_;
+    std::unordered_map<std::string, std::string> options_;
 };
 
-// Argument parser - Component A
-class ArgumentParser {
-private:
-    int argc;
-    const char** argv;
-    CryptoConfig config;
-
+// Abstract base: each concrete config subclass implements validate().
+class BaseCryptoConfig {
 public:
-    ArgumentParser(int argc_, const char** argv_);
+    virtual ~BaseCryptoConfig() = default;
+    virtual bool validate(const ArgumentParser& parser) = 0;
 
-    // Main parsing method
-    CryptoConfig parse();
-    CryptoConfig get_config() const;
+    bool        is_valid = false;
+    std::string error_message;
+};
 
-private:
-    void print_help() const;
+// Concrete config for the BMP/AES encryptor tool.
+class BmpCryptoConfig : public BaseCryptoConfig {
+public:
+    enum class Operation { ENCRYPT, DECRYPT, GENERATE_KEY };
+
+    bool validate(const ArgumentParser& parser) override;
+    void print_help(const ArgumentParser& parser) const;
+
+    // Factory methods
+    AESencryption::Key                           create_key()     const;
+    AESencryption::Cipher::OperationMode         create_optmode() const;
+
+    // Fields
+    Operation                                        operation      = Operation::ENCRYPT;
+    std::filesystem::path                            key_file, input_file, output_file, mode_file;
+    AESencryption::Key::LengthBits                   key_length     = AESencryption::Key::LengthBits::_128;
+    AESencryption::Cipher::OperationMode::Identifier operation_mode = AESencryption::Cipher::OperationMode::Identifier::CBC;
+    bool                                             show_metrics   = false;
 };
 
 } // namespace CLIConfig

--- a/crypto-cli/src/cli_config.cpp
+++ b/crypto-cli/src/cli_config.cpp
@@ -1,183 +1,191 @@
 #include "../include/cli_config.hpp"
+#include <iostream>
 
 using namespace CLIConfig;
 
-bool CryptoConfig::validate() {
-    // Check required fields based on operation
-    switch (this->operation) {
+// ── ArgumentParser ────────────────────────────────────────────────────────────
+
+ArgumentParser::ArgumentParser(int argc, const char** argv)
+    : argc_(argc), argv_(argv) {}
+
+void ArgumentParser::parse() {
+    for (int i = 1; i < argc_; ++i) {
+        std::string arg(argv_[i]);
+        if (arg.size() < 2 || arg[0] != '-' || arg[1] != '-')
+            continue;   // skip positional/non-flag tokens
+
+        bool next_is_value = (i + 1 < argc_) &&
+                             !(std::string(argv_[i + 1]).size() >= 2 &&
+                               argv_[i + 1][0] == '-' && argv_[i + 1][1] == '-');
+        if (next_is_value) {
+            options_[arg] = argv_[++i];
+        } else {
+            options_[arg] = "";   // boolean flag — present but no value
+        }
+    }
+}
+
+bool ArgumentParser::has(const std::string& flag) const {
+    return options_.count(flag) > 0;
+}
+
+std::string ArgumentParser::get(const std::string& flag) const {
+    auto it = options_.find(flag);
+    if (it == options_.end())
+        throw std::out_of_range("Missing required flag: " + flag);
+    return it->second;
+}
+
+std::string ArgumentParser::getOr(const std::string& flag,
+                                   const std::string& fallback) const {
+    auto it = options_.find(flag);
+    return (it != options_.end()) ? it->second : fallback;
+}
+
+const char* ArgumentParser::program_name() const {
+    return (argc_ > 0) ? argv_[0] : "";
+}
+
+// ── BmpCryptoConfig ───────────────────────────────────────────────────────────
+
+bool BmpCryptoConfig::validate(const ArgumentParser& parser) {
+    if (parser.has("--help")) {
+        print_help(parser);
+        is_valid = false;
+        return false;
+    }
+
+    // Operation (last flag checked first so precedence matches intent)
+    if      (parser.has("--generate-key")) operation = Operation::GENERATE_KEY;
+    else if (parser.has("--decrypt"))      operation = Operation::DECRYPT;
+    else if (parser.has("--encrypt"))      operation = Operation::ENCRYPT;
+    // else: default is ENCRYPT
+
+    // File paths
+    key_file    = parser.getOr("--key",       "");
+    input_file  = parser.getOr("--input",     "");
+    output_file = parser.getOr("--output",    "");
+    mode_file   = parser.getOr("--mode-data", "");
+
+    // Operation mode
+    std::string mode_str = parser.getOr("--mode", "");
+    if (!mode_str.empty()) {
+        if      (mode_str == "ECB") operation_mode = AESencryption::Cipher::OperationMode::Identifier::ECB;
+        else if (mode_str == "CBC") operation_mode = AESencryption::Cipher::OperationMode::Identifier::CBC;
+        else if (mode_str == "OFB") operation_mode = AESencryption::Cipher::OperationMode::Identifier::OFB;
+        else if (mode_str == "CTR") operation_mode = AESencryption::Cipher::OperationMode::Identifier::CTR;
+        else {
+            error_message = "Invalid mode: " + mode_str + ". Use ECB, CBC, OFB, or CTR.";
+            is_valid = false;
+            return false;
+        }
+    }
+
+    // Key length
+    std::string kl_str = parser.getOr("--key-length", "");
+    if (!kl_str.empty()) {
+        try {
+            int bits = std::stoi(kl_str);
+            if      (bits == 128) key_length = AESencryption::Key::LengthBits::_128;
+            else if (bits == 192) key_length = AESencryption::Key::LengthBits::_192;
+            else if (bits == 256) key_length = AESencryption::Key::LengthBits::_256;
+            else {
+                error_message = "Invalid key length: " + kl_str + ". Use 128, 192, or 256.";
+                is_valid = false;
+                return false;
+            }
+        } catch (const std::exception&) {
+            error_message = "Invalid key length: " + kl_str + ". Use 128, 192, or 256.";
+            is_valid = false;
+            return false;
+        }
+    }
+
+    // Boolean flags
+    show_metrics = parser.has("--show-metrics");
+
+    // Structural validation
+    switch (operation) {
         case Operation::ENCRYPT:
         case Operation::DECRYPT:
-            if (this->key_file.empty()) {
-                this->error_message = "Key file is required for encryption/decryption";
+            if (key_file.empty()) {
+                error_message = "Key file is required for encryption/decryption";
                 return false;
             }
-            if (this->input_file.empty()) {
-                this->error_message = "Input file is required";
+            if (input_file.empty()) {
+                error_message = "Input file is required";
                 return false;
             }
-            if (this->output_file.empty()) {
-                this->error_message = "Output file is required";
+            if (output_file.empty()) {
+                error_message = "Output file is required";
                 return false;
             }
-            if(this->operation == Operation::DECRYPT){
-                if(this->mode_file.empty() && this->operation_mode != AESencryption::Cipher::OperationMode::Identifier::ECB){
-                    this->error_message = "Missing initial vector, nonce, counter or oder required data";
+            if (operation == Operation::DECRYPT) {
+                if (mode_file.empty() &&
+                    operation_mode != AESencryption::Cipher::OperationMode::Identifier::ECB) {
+                    error_message = "Missing initial vector, nonce, counter or oder required data";
                     return false;
                 }
             }
             break;
         case Operation::GENERATE_KEY:
-            if (this->output_file.empty()) {
-                this->error_message = "Output file is required for key generation";
+            if (output_file.empty()) {
+                error_message = "Output file is required for key generation";
                 return false;
             }
             break;
     }
-    if(this->show_metrics){
-        if (this->input_file.empty()) {
-            this->error_message = "Input file is required";
+    if (show_metrics) {
+        if (input_file.empty()) {
+            error_message = "Input file is required";
             return false;
         }
-        if (this->output_file.empty()) {
-            this->error_message = "Output file is required";
+        if (output_file.empty()) {
+            error_message = "Output file is required";
             return false;
         }
     }
-    this->is_valid = true;
+
+    is_valid = true;
     return true;
 }
 
-AESencryption::Key CryptoConfig::create_key() const {
-    if (!this->is_valid) {
-        throw std::runtime_error("Cannot create key from invalid configuration");
-    }
-    if (this->operation == Operation::GENERATE_KEY) {
-        // Generate new random key (constructor to be implemented)
-        return AESencryption::Key(this->key_length);
-    } else {
-        // Load key from file
-        try{
-            return AESencryption::Key(this->key_file.c_str());
-        } catch(const std::exception& exp){
-            throw;
-        }
-    }
-}
-
-AESencryption::Cipher::OperationMode CryptoConfig::create_optmode() const{
-    if(!this->is_valid){
-        throw std::runtime_error("Cannot create operation mode object from invalid configuration");
-    }
-    if(!this->mode_file.empty()){
-        try{
-            return AESencryption::Cipher::OperationMode::loadFromFile(this->mode_file);
-        } catch(const std::exception& e){
-            throw;
-        }
-    }
-    return AESencryption::Cipher::OperationMode(this->operation_mode);
-}
-
-ArgumentParser::ArgumentParser(int argc_, const char** argv_) : argc(argc_), argv(argv_) {}
-
-CryptoConfig ArgumentParser::parse() {
-    if (argc < 2) {
-        this->config.error_message = "No arguments provided. Use --help for usage information.";
-        this->config.is_valid = false;
-        return this->config;
-    }
-
-    // Parse arguments
-    for (int i = 1; i < argc; i++) {
-        std::string arg(argv[i]);
-
-        // Options that require an additional argument
-        if (arg == "--key" && i + 1 < argc) {
-            this->config.key_file = argv[++i];
-        }
-        else if (arg == "--input" && i + 1 < argc) {
-            this->config.input_file = argv[++i];
-        }
-        else if (arg == "--output" && i + 1 < argc) {
-            this->config.output_file = argv[++i];
-        }
-        else if (arg == "--mode-data" && i + 1 < argc) {
-            this->config.mode_file = argv[++i];
-        }
-        else if (arg == "--mode" && i + 1 < argc) {
-            std::string mode(argv[++i]);
-            if (mode == "ECB") {
-                this->config.operation_mode = AESencryption::Cipher::OperationMode::Identifier::ECB;
-            } else if (mode == "CBC") {
-                this->config.operation_mode = AESencryption::Cipher::OperationMode::Identifier::CBC;
-            } else if (mode == "OFB") {
-                this->config.operation_mode = AESencryption::Cipher::OperationMode::Identifier::OFB;
-            } else if (mode == "CTR") {
-                this->config.operation_mode = AESencryption::Cipher::OperationMode::Identifier::CTR;
-            } else {
-                this->config.error_message = "Invalid mode: " + mode + ". Use ECB, CBC, OFB, or CTR.";
-                this->config.is_valid = false;
-                return this->config;
-            }
-        }
-        else if (arg == "--key-length" && i + 1 < argc) {
-            int bits = std::stoi(argv[++i]);
-            if (bits == 128) {
-                this->config.key_length = AESencryption::Key::LengthBits::_128;
-            } else if (bits == 192) {
-                this->config.key_length = AESencryption::Key::LengthBits::_192;
-            } else if (bits == 256) {
-                this->config.key_length = AESencryption::Key::LengthBits::_256;
-                } else {
-                this->config.error_message = "Invalid key length: " + std::to_string(bits) +
-                                     ". Use 128, 192, or 256.";
-                this->config.is_valid = false;
-                return this->config;
-            }
-        }   // Options that do not require an additional argument
-        else if (arg == "--generate-key") {
-            this->config.operation = CryptoConfig::Operation::GENERATE_KEY;
-        }
-        else if (arg == "--encrypt") {
-            this->config.operation = CryptoConfig::Operation::ENCRYPT;
-        }
-        else if (arg == "--decrypt") {
-            this->config.operation = CryptoConfig::Operation::DECRYPT;
-        }
-        else if (arg == "--show-metrics") {
-            this->config.show_metrics = true;
-        }
-        else if (arg == "--help") {
-            print_help();
-            this->config.is_valid = false;
-            return this->config;
-        }
-        else {
-            this->config.error_message = "Unknown argument: " + arg;
-            this->config.is_valid = false;
-            return this->config;
-        }
-    }
-
-    // Validate the configuration
-    this->config.validate();
-    return this->config;
-}
-
-CryptoConfig ArgumentParser::get_config() const {
-    return this->config;
-}
-
-void ArgumentParser::print_help() const{
-    std::cout << this->argv[0] << ". AES Encryption Tool\n\n"
+void BmpCryptoConfig::print_help(const ArgumentParser& parser) const {
+    const char* prog = parser.program_name();
+    std::cout << prog << ". AES Encryption Tool\n\n"
               << "Usage:\n"
-              << "\tEncryption\t" << this->argv[0] << " --encrypt --key <keyfile> --input <file> --output <file> [options]\n"
-              << "\tDecryption\t" << this->argv[0] << " --decrypt --key <keyfile> --input <file> --output <file> --mode-data <file> [options]\n"
-              << "\tKey Generation:\t" << this->argv[0] << " --generate-key --key-length <bits> --output <file>\n\n"
+              << "\tEncryption\t"   << prog << " --encrypt --key <keyfile> --input <file> --output <file> [options]\n"
+              << "\tDecryption\t"   << prog << " --decrypt --key <keyfile> --input <file> --output <file> --mode-data <file> [options]\n"
+              << "\tKey Generation:\t" << prog << " --generate-key --key-length <bits> --output <file>\n\n"
               << "Options:\n"
               << "\t--key-length <bits>      Key length: 128, 192, or 256 (default: 128)\n"
               << "\t--mode <ECB|CBC|OFB|CTR> Operation mode (default: CBC)\n"
               << "\t--mode-data <file>       Required data for specific operation mode\n"
               << "\t--show-metrics           Show statistical metrics from input and output\n"
               << "\t--help                   Show this help message\n";
+}
+
+AESencryption::Key BmpCryptoConfig::create_key() const {
+    if (!is_valid)
+        throw std::runtime_error("Cannot create key from invalid configuration");
+    if (operation == Operation::GENERATE_KEY)
+        return AESencryption::Key(key_length);
+    try {
+        return AESencryption::Key(key_file.c_str());
+    } catch (const std::exception&) {
+        throw;
+    }
+}
+
+AESencryption::Cipher::OperationMode BmpCryptoConfig::create_optmode() const {
+    if (!is_valid)
+        throw std::runtime_error("Cannot create operation mode object from invalid configuration");
+    if (!mode_file.empty()) {
+        try {
+            return AESencryption::Cipher::OperationMode::loadFromFile(mode_file);
+        } catch (const std::exception&) {
+            throw;
+        }
+    }
+    return AESencryption::Cipher::OperationMode(operation_mode);
 }

--- a/crypto-cli/src/cli_config.cpp
+++ b/crypto-cli/src/cli_config.cpp
@@ -46,9 +46,9 @@ const char* ArgumentParser::program_name() const {
     return (argc_ > 0) ? argv_[0] : "";
 }
 
-// ── BmpCryptoConfig ───────────────────────────────────────────────────────────
+// ── FileCryptoConfig ──────────────────────────────────────────────────────────
 
-bool BmpCryptoConfig::validate(const ArgumentParser& parser) {
+bool FileCryptoConfig::validate(const ArgumentParser& parser) {
     if (parser.has("--help")) {
         print_help(parser);
         is_valid = false;
@@ -101,9 +101,6 @@ bool BmpCryptoConfig::validate(const ArgumentParser& parser) {
         }
     }
 
-    // Boolean flags
-    show_metrics = parser.has("--show-metrics");
-
     // Structural validation
     switch (operation) {
         case Operation::ENCRYPT:
@@ -135,22 +132,12 @@ bool BmpCryptoConfig::validate(const ArgumentParser& parser) {
             }
             break;
     }
-    if (show_metrics) {
-        if (input_file.empty()) {
-            error_message = "Input file is required";
-            return false;
-        }
-        if (output_file.empty()) {
-            error_message = "Output file is required";
-            return false;
-        }
-    }
 
     is_valid = true;
     return true;
 }
 
-void BmpCryptoConfig::print_help(const ArgumentParser& parser) const {
+void FileCryptoConfig::print_help(const ArgumentParser& parser) const {
     const char* prog = parser.program_name();
     std::cout << prog << ". AES Encryption Tool\n\n"
               << "Usage:\n"
@@ -161,11 +148,10 @@ void BmpCryptoConfig::print_help(const ArgumentParser& parser) const {
               << "\t--key-length <bits>      Key length: 128, 192, or 256 (default: 128)\n"
               << "\t--mode <ECB|CBC|OFB|CTR> Operation mode (default: CBC)\n"
               << "\t--mode-data <file>       Required data for specific operation mode\n"
-              << "\t--show-metrics           Show statistical metrics from input and output\n"
               << "\t--help                   Show this help message\n";
 }
 
-AESencryption::Key BmpCryptoConfig::create_key() const {
+AESencryption::Key FileCryptoConfig::create_key() const {
     if (!is_valid)
         throw std::runtime_error("Cannot create key from invalid configuration");
     if (operation == Operation::GENERATE_KEY)
@@ -177,7 +163,7 @@ AESencryption::Key BmpCryptoConfig::create_key() const {
     }
 }
 
-AESencryption::Cipher::OperationMode BmpCryptoConfig::create_optmode() const {
+AESencryption::Cipher::OperationMode FileCryptoConfig::create_optmode() const {
     if (!is_valid)
         throw std::runtime_error("Cannot create operation mode object from invalid configuration");
     if (!mode_file.empty()) {

--- a/tests/integration/test_cli_crypto_config.cpp
+++ b/tests/integration/test_cli_crypto_config.cpp
@@ -103,14 +103,16 @@ bool test_valid_encryption_arguments() {
 
     // Parse arguments
     CLIConfig::ArgumentParser parser(argc, argv);
-    CLIConfig::CryptoConfig config = parser.parse();
+    parser.parse();
+    CLIConfig::BmpCryptoConfig config;
+    config.validate(parser);
 
     // Test: Configuration should be valid
     success &= ASSERT_TRUE(config.is_valid, "Configuration should be valid with all required arguments");
     success &= ASSERT_TRUE(config.error_message.empty(), "No error message should be present");
 
     // Test: Configuration values match arguments
-    success &= ASSERT_TRUE(config.operation == CLIConfig::CryptoConfig::Operation::ENCRYPT,
+    success &= ASSERT_TRUE(config.operation == CLIConfig::BmpCryptoConfig::Operation::ENCRYPT,
                 "Operation should be ENCRYPT");
     success &= ASSERT_TRUE(config.key_file == "test_key.bin", "Key file should match argument");
     success &= ASSERT_TRUE(config.input_file == "plaintext.txt", "Input file should match argument");
@@ -144,7 +146,9 @@ bool test_argument_to_crypto_type_conversion() {
             .build(argc);
 
         CLIConfig::ArgumentParser parser(argc, argv);
-        CLIConfig::CryptoConfig config = parser.parse();
+        parser.parse();
+        CLIConfig::BmpCryptoConfig config;
+        config.validate(parser);
 
         success &= ASSERT_TRUE(config.operation_mode == AESencryption::Cipher::OperationMode::Identifier::ECB,
                     "String 'ECB' should convert to OperationMode::Identifier::ECB");
@@ -164,7 +168,9 @@ bool test_argument_to_crypto_type_conversion() {
             .build(argc);
 
         CLIConfig::ArgumentParser parser(argc, argv);
-        CLIConfig::CryptoConfig config = parser.parse();
+        parser.parse();
+        CLIConfig::BmpCryptoConfig config;
+        config.validate(parser);
 
         success &= ASSERT_TRUE(config.is_valid,
                     "Key length " + std::to_string(bits) + " should be valid");
@@ -197,7 +203,9 @@ bool test_invalid_arguments_prevent_crypto_initialization() {
             .build(argc);
 
         CLIConfig::ArgumentParser parser(argc, argv);
-        CLIConfig::CryptoConfig config = parser.parse();
+        parser.parse();
+        CLIConfig::BmpCryptoConfig config;
+        config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "Invalid key length should mark config invalid");
         success &= ASSERT_TRUE(!config.error_message.empty(), "Error message should be provided");
@@ -219,7 +227,9 @@ bool test_invalid_arguments_prevent_crypto_initialization() {
             .build(argc);
 
         CLIConfig::ArgumentParser parser(argc, argv);
-        CLIConfig::CryptoConfig config = parser.parse();
+        parser.parse();
+        CLIConfig::BmpCryptoConfig config;
+        config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "Invalid mode should mark config invalid");
         success &= ASSERT_TRUE(config.error_message.find("XTS") != std::string::npos,
@@ -228,7 +238,7 @@ bool test_invalid_arguments_prevent_crypto_initialization() {
 
     // Test: Attempting to create key from invalid config should throw
     {
-        CLIConfig::CryptoConfig invalid_config;
+        CLIConfig::BmpCryptoConfig invalid_config;
         invalid_config.is_valid = false;
         invalid_config.error_message = "Test error";
 
@@ -262,7 +272,9 @@ bool test_missing_required_arguments() {
             .build(argc);
 
         CLIConfig::ArgumentParser parser(argc, argv);
-        CLIConfig::CryptoConfig config = parser.parse();
+        parser.parse();
+        CLIConfig::BmpCryptoConfig config;
+        config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "Missing key file should invalidate config");
         success &= ASSERT_TRUE(config.error_message.find("key") != std::string::npos ||
@@ -282,7 +294,9 @@ bool test_missing_required_arguments() {
             .build(argc);
 
         CLIConfig::ArgumentParser parser(argc, argv);
-        CLIConfig::CryptoConfig config = parser.parse();
+        parser.parse();
+        CLIConfig::BmpCryptoConfig config;
+        config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "Missing input file should invalidate config");
         success &= ASSERT_TRUE(config.error_message.find("input") != std::string::npos ||
@@ -296,7 +310,9 @@ bool test_missing_required_arguments() {
         const char* argv[] = {"aes-encryption"};
 
         CLIConfig::ArgumentParser parser(argc, argv);
-        CLIConfig::CryptoConfig config = parser.parse();
+        parser.parse();
+        CLIConfig::BmpCryptoConfig config;
+        config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "No arguments should invalidate config");
     }
@@ -322,7 +338,9 @@ bool test_default_values() {
         .build(argc);
 
     CLIConfig::ArgumentParser parser(argc, argv);
-    CLIConfig::CryptoConfig config = parser.parse();
+    parser.parse();
+    CLIConfig::BmpCryptoConfig config;
+    config.validate(parser);
 
     success &= ASSERT_TRUE(config.is_valid, "Config should be valid with defaults");
     success &= ASSERT_TRUE(config.operation_mode == AESencryption::Cipher::OperationMode::Identifier::CBC,
@@ -353,10 +371,12 @@ bool test_config_creates_functional_crypto_objects() {
         .build(argc);
 
     CLIConfig::ArgumentParser parser(argc, argv);
-    CLIConfig::CryptoConfig config = parser.parse();
+    parser.parse();
+    CLIConfig::BmpCryptoConfig config;
+    config.validate(parser);
 
     success &= ASSERT_TRUE(config.is_valid, "Key generation config should be valid");
-    success &= ASSERT_TRUE(config.operation == CLIConfig::CryptoConfig::Operation::GENERATE_KEY,
+    success &= ASSERT_TRUE(config.operation == CLIConfig::BmpCryptoConfig::Operation::GENERATE_KEY,
                 "Operation should be GENERATE_KEY");
     success &= ASSERT_TRUE(config.key_length == AESencryption::Key::LengthBits::_256,
                 "Key length should be 256");
@@ -386,9 +406,11 @@ bool test_argument_format_variations() {
             .build(argc);
 
         CLIConfig::ArgumentParser parser(argc, argv);
-        CLIConfig::CryptoConfig config = parser.parse();
+        parser.parse();
+        CLIConfig::BmpCryptoConfig config;
+        config.validate(parser);
 
-        success &= ASSERT_TRUE(config.operation == CLIConfig::CryptoConfig::Operation::DECRYPT,
+        success &= ASSERT_TRUE(config.operation == CLIConfig::BmpCryptoConfig::Operation::DECRYPT,
                     "Program option --decrypt should affect operation detection");
     }
 

--- a/tests/integration/test_cli_crypto_config.cpp
+++ b/tests/integration/test_cli_crypto_config.cpp
@@ -104,7 +104,7 @@ bool test_valid_encryption_arguments() {
     // Parse arguments
     CLIConfig::ArgumentParser parser(argc, argv);
     parser.parse();
-    CLIConfig::BmpCryptoConfig config;
+    CLIConfig::FileCryptoConfig config;
     config.validate(parser);
 
     // Test: Configuration should be valid
@@ -112,7 +112,7 @@ bool test_valid_encryption_arguments() {
     success &= ASSERT_TRUE(config.error_message.empty(), "No error message should be present");
 
     // Test: Configuration values match arguments
-    success &= ASSERT_TRUE(config.operation == CLIConfig::BmpCryptoConfig::Operation::ENCRYPT,
+    success &= ASSERT_TRUE(config.operation == CLIConfig::FileCryptoConfig::Operation::ENCRYPT,
                 "Operation should be ENCRYPT");
     success &= ASSERT_TRUE(config.key_file == "test_key.bin", "Key file should match argument");
     success &= ASSERT_TRUE(config.input_file == "plaintext.txt", "Input file should match argument");
@@ -147,7 +147,7 @@ bool test_argument_to_crypto_type_conversion() {
 
         CLIConfig::ArgumentParser parser(argc, argv);
         parser.parse();
-        CLIConfig::BmpCryptoConfig config;
+        CLIConfig::FileCryptoConfig config;
         config.validate(parser);
 
         success &= ASSERT_TRUE(config.operation_mode == AESencryption::Cipher::OperationMode::Identifier::ECB,
@@ -169,7 +169,7 @@ bool test_argument_to_crypto_type_conversion() {
 
         CLIConfig::ArgumentParser parser(argc, argv);
         parser.parse();
-        CLIConfig::BmpCryptoConfig config;
+        CLIConfig::FileCryptoConfig config;
         config.validate(parser);
 
         success &= ASSERT_TRUE(config.is_valid,
@@ -204,7 +204,7 @@ bool test_invalid_arguments_prevent_crypto_initialization() {
 
         CLIConfig::ArgumentParser parser(argc, argv);
         parser.parse();
-        CLIConfig::BmpCryptoConfig config;
+        CLIConfig::FileCryptoConfig config;
         config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "Invalid key length should mark config invalid");
@@ -228,7 +228,7 @@ bool test_invalid_arguments_prevent_crypto_initialization() {
 
         CLIConfig::ArgumentParser parser(argc, argv);
         parser.parse();
-        CLIConfig::BmpCryptoConfig config;
+        CLIConfig::FileCryptoConfig config;
         config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "Invalid mode should mark config invalid");
@@ -238,7 +238,7 @@ bool test_invalid_arguments_prevent_crypto_initialization() {
 
     // Test: Attempting to create key from invalid config should throw
     {
-        CLIConfig::BmpCryptoConfig invalid_config;
+        CLIConfig::FileCryptoConfig invalid_config;
         invalid_config.is_valid = false;
         invalid_config.error_message = "Test error";
 
@@ -273,7 +273,7 @@ bool test_missing_required_arguments() {
 
         CLIConfig::ArgumentParser parser(argc, argv);
         parser.parse();
-        CLIConfig::BmpCryptoConfig config;
+        CLIConfig::FileCryptoConfig config;
         config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "Missing key file should invalidate config");
@@ -295,7 +295,7 @@ bool test_missing_required_arguments() {
 
         CLIConfig::ArgumentParser parser(argc, argv);
         parser.parse();
-        CLIConfig::BmpCryptoConfig config;
+        CLIConfig::FileCryptoConfig config;
         config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "Missing input file should invalidate config");
@@ -311,7 +311,7 @@ bool test_missing_required_arguments() {
 
         CLIConfig::ArgumentParser parser(argc, argv);
         parser.parse();
-        CLIConfig::BmpCryptoConfig config;
+        CLIConfig::FileCryptoConfig config;
         config.validate(parser);
 
         success &= ASSERT_TRUE(!config.is_valid, "No arguments should invalidate config");
@@ -339,7 +339,7 @@ bool test_default_values() {
 
     CLIConfig::ArgumentParser parser(argc, argv);
     parser.parse();
-    CLIConfig::BmpCryptoConfig config;
+    CLIConfig::FileCryptoConfig config;
     config.validate(parser);
 
     success &= ASSERT_TRUE(config.is_valid, "Config should be valid with defaults");
@@ -372,11 +372,11 @@ bool test_config_creates_functional_crypto_objects() {
 
     CLIConfig::ArgumentParser parser(argc, argv);
     parser.parse();
-    CLIConfig::BmpCryptoConfig config;
+    CLIConfig::FileCryptoConfig config;
     config.validate(parser);
 
     success &= ASSERT_TRUE(config.is_valid, "Key generation config should be valid");
-    success &= ASSERT_TRUE(config.operation == CLIConfig::BmpCryptoConfig::Operation::GENERATE_KEY,
+    success &= ASSERT_TRUE(config.operation == CLIConfig::FileCryptoConfig::Operation::GENERATE_KEY,
                 "Operation should be GENERATE_KEY");
     success &= ASSERT_TRUE(config.key_length == AESencryption::Key::LengthBits::_256,
                 "Key length should be 256");
@@ -407,10 +407,10 @@ bool test_argument_format_variations() {
 
         CLIConfig::ArgumentParser parser(argc, argv);
         parser.parse();
-        CLIConfig::BmpCryptoConfig config;
+        CLIConfig::FileCryptoConfig config;
         config.validate(parser);
 
-        success &= ASSERT_TRUE(config.operation == CLIConfig::BmpCryptoConfig::Operation::DECRYPT,
+        success &= ASSERT_TRUE(config.operation == CLIConfig::FileCryptoConfig::Operation::DECRYPT,
                     "Program option --decrypt should affect operation detection");
     }
 


### PR DESCRIPTION
refactor(crypto-cli): modularize CLI config into layered class hierarchy                                                                            
  
## Summary                                                                                                                                             
                                                                                                                                                    
Refactors the monolithic CLI configuration code into a clean, layered hierarchy to separate generic file-encryption concerns from tool-specific ones.

Before: A single BmpCryptoConfig class in the shared crypto-cli library handled everything — argument parsing, AES configuration, and BMP-specific options (--show-metrics).

After:
BaseCryptoConfig          ← abstract base (unchanged)
└── FileCryptoConfig      ← generic file encryption config (new, in crypto-cli library)
    └── BmpCryptoConfig   ← BMP tool-specific extension (local to bmp_encryptor.cpp)
    └── HSMCryptoConfig   ← HSM tool-specific config (inherits BaseCryptoConfig directly)

## Changes

- crypto-cli/include/cli_config.hpp / cli_config.cpp: Introduced ArgumentParser (dumb tokenizer), BaseCryptoConfig (abstract base), and FileCryptoConfig (generic AES file encryption config with validate(), print_help(), create_key(), create_optmode()). print_help() is marked virtual to allow tool-specific subclasses to extend it.
- bmp_encryptor.cpp: Defines a local BmpCryptoConfig : FileCryptoConfig that adds show_metrics, extends validate() (chains to base then applies --show-metrics logic), and overrides print_help() to include the --show-metrics option line. main() is unchanged.
- hsm_encrypt.cpp: Introduced HSMCryptoConfig : BaseCryptoConfig for the HSM tool, using the shared ArgumentParser tokenizer.
- tests/integration/test_cli_crypto_config.cpp: Updated to use CLIConfig::FileCryptoConfig — all 7 tests cover behavior that belongs to the generic layer.