### PR TITLE
feat(image-encryptor): JPEG support, UX redesign, and --metadata flag

### DIFF
--- a/cli-tools/include/cli_config.hpp
+++ b/cli-tools/include/cli_config.hpp
@@ -52,7 +52,7 @@ public:
 
     // Fields
     Operation                                        operation      = Operation::ENCRYPT;
-    std::filesystem::path                            key_file, input_file, output_file, mode_file;
+    std::filesystem::path                            key_file, input_file, output_file, metadata_file;
     CipherFortis::Key::LengthBits                   key_length     = CipherFortis::Key::LengthBits::_128;
     CipherFortis::Cipher::OperationMode::Identifier operation_mode = CipherFortis::Cipher::OperationMode::Identifier::CBC;
 };

--- a/cli-tools/src/cli_config.cpp
+++ b/cli-tools/src/cli_config.cpp
@@ -65,7 +65,7 @@ bool FileCryptoConfig::validate(const ArgumentParser& parser) {
     key_file    = parser.getOr("--key",       "");
     input_file  = parser.getOr("--input",     "");
     output_file = parser.getOr("--output",    "");
-    mode_file   = parser.getOr("--mode-data", "");
+    metadata_file = parser.getOr("--metadata", "");
 
     // Operation mode
     std::string mode_str = parser.getOr("--mode", "");
@@ -118,7 +118,7 @@ bool FileCryptoConfig::validate(const ArgumentParser& parser) {
                 return false;
             }
             if (operation == Operation::DECRYPT) {
-                if (mode_file.empty() &&
+                if (metadata_file.empty() &&
                     operation_mode != CipherFortis::Cipher::OperationMode::Identifier::ECB) {
                     error_message = "Missing initial vector, nonce, counter or oder required data";
                     return false;
@@ -142,12 +142,12 @@ void FileCryptoConfig::print_help(const ArgumentParser& parser) const {
     std::cout << prog << ". AES Encryption Tool\n\n"
               << "Usage:\n"
               << "\tEncryption\t"   << prog << " --encrypt --key <keyfile> --input <file> --output <file> [options]\n"
-              << "\tDecryption\t"   << prog << " --decrypt --key <keyfile> --input <file> --output <file> --mode-data <file> [options]\n"
+              << "\tDecryption\t"   << prog << " --decrypt --key <keyfile> --input <file> --output <file> --metadata <file> [options]\n"
               << "\tKey Generation:\t" << prog << " --generate-key --key-length <bits> --output <file>\n\n"
               << "Options:\n"
               << "\t--key-length <bits>      Key length: 128, 192, or 256 (default: 128)\n"
               << "\t--mode <ECB|CBC|OFB|CTR> Operation mode (default: CBC)\n"
-              << "\t--mode-data <file>       Required data for specific operation mode\n"
+              << "\t--metadata <file>        JSON file to save/load mode and IV for round-trip\n"
               << "\t--help                   Show this help message\n";
 }
 
@@ -166,9 +166,9 @@ CipherFortis::Key FileCryptoConfig::create_key() const {
 CipherFortis::Cipher::OperationMode FileCryptoConfig::create_optmode() const {
     if (!is_valid)
         throw std::runtime_error("Cannot create operation mode object from invalid configuration");
-    if (!mode_file.empty()) {
+    if (!metadata_file.empty()) {
         try {
-            return CipherFortis::Cipher::OperationMode::loadFromFile(mode_file);
+            return CipherFortis::Cipher::OperationMode::loadFromFile(metadata_file);
         } catch (const std::exception&) {
             throw;
         }

--- a/command-line-tools/hsm-encrypt/hsm_encrypt.cpp
+++ b/command-line-tools/hsm-encrypt/hsm_encrypt.cpp
@@ -6,6 +6,7 @@
 #include "../../file-handlers/include/file_base.hpp"
 #include "../../cli-tools/include/cli_config.hpp"
 
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -55,7 +56,7 @@ public:
     void print_help(const CLIConfig::ArgumentParser& parser) const;
 
     std::string lib_path, token, pin, key_label, input_file, output_file;
-    std::string iv_hex;
+    std::string iv_hex, metadata_file;
     bool        decrypt        = false;
     Cipher::OperationMode::Identifier operation_mode = Cipher::OperationMode::Identifier::CBC;
     Key::LengthBits                   key_length     = Key::LengthBits::_128;
@@ -68,8 +69,9 @@ bool HSMCryptoConfig::validate(const CLIConfig::ArgumentParser& parser) {
     key_label   = parser.getOr("--key",     "");
     input_file  = parser.getOr("--input",   "");
     output_file = parser.getOr("--output",  "");
-    iv_hex      = parser.getOr("--iv",      "");
-    decrypt     = parser.has("--decrypt");
+    iv_hex        = parser.getOr("--iv",       "");
+    metadata_file = parser.getOr("--metadata", "");
+    decrypt       = parser.has("--decrypt");
 
     // Check required fields
     for (auto& [name, val] : std::vector<std::pair<std::string, std::string>>{
@@ -127,7 +129,37 @@ void HSMCryptoConfig::print_help(const CLIConfig::ArgumentParser& parser) const 
         << "\nOptional:\n"
         << "  --decrypt        Decrypt instead of encrypt (default: encrypt)\n"
         << "  --iv     HEX     16-byte IV as 32 hex characters (CBC/CTR)\n"
-        << "                   If omitted, a random IV is generated and printed\n";
+        << "                   If omitted, a random IV is generated and printed\n"
+        << "  --metadata FILE  JSON file to save IV+mode on encrypt,\n"
+        << "                   or load IV+mode on decrypt (replaces --iv)\n";
+}
+
+static void write_metadata(const std::string& path,
+                            const std::string& mode, const std::string& iv_hex) {
+    std::ofstream f(path);
+    if (!f) throw std::runtime_error("Cannot open metadata file for writing: " + path);
+    f << "{\n  \"mode\": \"" << mode << "\"";
+    if (!iv_hex.empty())
+        f << ",\n  \"iv\": \"" << iv_hex << "\"";
+    f << "\n}\n";
+}
+
+static void read_metadata(const std::string& path,
+                           std::string& mode, std::string& iv_hex) {
+    std::ifstream f(path);
+    if (!f) throw std::runtime_error("Cannot open metadata file: " + path);
+    std::string content((std::istreambuf_iterator<char>(f)),
+                         std::istreambuf_iterator<char>());
+    auto extract = [&](const std::string& key) -> std::string {
+        std::string search = "\"" + key + "\": \"";
+        auto pos = content.find(search);
+        if (pos == std::string::npos) return "";
+        pos += search.size();
+        auto end = content.find("\"", pos);
+        return (end != std::string::npos) ? content.substr(pos, end - pos) : "";
+    };
+    mode   = extract("mode");
+    iv_hex = extract("iv");
 }
 
 static std::string bytes_to_hex(const std::vector<uint8_t>& bytes) {
@@ -156,6 +188,16 @@ int main(int argc, const char* argv[]) {
     }
 
     try {
+        // ── Load metadata for decrypt if provided ─────────────────────────────
+        if (config.decrypt && !config.metadata_file.empty()) {
+            std::string mode_str, iv_from_meta;
+            read_metadata(config.metadata_file, mode_str, iv_from_meta);
+            if (!mode_str.empty())
+                config.operation_mode = Cipher::OperationMode::string_to_identifier(mode_str);
+            if (config.iv_hex.empty())
+                config.iv_hex = iv_from_meta;
+        }
+
         // ── Session & cipher setup ────────────────────────────────────────────
         HSMSession session(config.lib_path, config.token, config.pin);
         HSMCipher  cipher(session, config.operation_mode);
@@ -172,6 +214,7 @@ int main(int argc, const char* argv[]) {
         cipher.setActiveKey(key);
 
         // ── IV handling ───────────────────────────────────────────────────────
+        std::vector<uint8_t> iv_used;
         if (mode_needs_iv(config.operation_mode)) {
             std::vector<uint8_t> iv;
             if (!config.iv_hex.empty()) {
@@ -188,6 +231,7 @@ int main(int argc, const char* argv[]) {
                           << bytes_to_hex(iv) << "\n";
             }
             cipher.setIV(iv);
+            iv_used = iv;
         }
 
         // ── File I/O via FileBase ─────────────────────────────────────────────
@@ -205,6 +249,12 @@ int main(int argc, const char* argv[]) {
         }
 
         file.save(config.output_file);
+
+        if (!config.decrypt && !config.metadata_file.empty()) {
+            write_metadata(config.metadata_file,
+                           Cipher::OperationMode::identifier_to_string(config.operation_mode),
+                           bytes_to_hex(iv_used));
+        }
 
     } catch (const PKCS11Exception& e) {
         std::cerr << "[PKCS#11 error] " << e.what() << "\n";

--- a/command-line-tools/image-encryption/image_encryptor.cpp
+++ b/command-line-tools/image-encryption/image_encryptor.cpp
@@ -137,17 +137,6 @@ bool ImageCryptoConfig::validate(const CLIConfig::ArgumentParser& parser) {
         }
     }
 
-    // Warn if the input is a JPEG
-    if (image_is_lossy(input_file)) {
-        std::cerr
-            << "Warning: '" << std::filesystem::path(input_file).filename().string()
-            << "' is a JPEG.\n"
-            << "  JPEG uses lossy compression. Encrypted bytes will be altered\n"
-            << "  by the codec on save, so decryption will NOT restore the\n"
-            << "  original image. The visual encryption effect is still visible.\n"
-            << "  Use BMP or PNG for a lossless round-trip.\n\n";
-    }
-
     is_valid = true;
     return true;
 }
@@ -175,8 +164,8 @@ void ImageCryptoConfig::print_help(const CLIConfig::ArgumentParser& parser) cons
         << "  --help                     Show this help message\n\n"
         << "Notes:\n"
         << "  BMP and PNG support lossless round-trips (encrypt then decrypt\n"
-        << "  recovers the original). JPEG is lossy: decryption will not\n"
-        << "  restore the original image.\n";
+        << "  recovers the original). JPEG will be saved as PNG (lossless)\n"
+        << "  to preserve encrypted pixels.\n";
 }
 
 // ── main ──────────────────────────────────────────────────────────────────────
@@ -218,6 +207,13 @@ int main(int argc, const char* argv[]) {
             const uint8_t* iv_ptr = optmode.getIVpointerData();
             std::cout << "Generated IV (save for decryption): "
                       << bytes_to_hex(iv_ptr, 16) << "\n";
+        }
+
+        if (!config.decrypt && image_is_lossy(config.input_file)) {
+            config.output_file = std::filesystem::path(config.output_file)
+                                     .replace_extension(".png").string();
+            std::cout << "Note: JPEG input will be saved as PNG to preserve encrypted pixels.\n"
+                      << "      Output: " << config.output_file << "\n";
         }
 
         std::unique_ptr<FileBase> image = make_image(config.input_file);

--- a/command-line-tools/image-encryption/image_encryptor.cpp
+++ b/command-line-tools/image-encryption/image_encryptor.cpp
@@ -2,9 +2,9 @@
  * @file image_encryptor.cpp
  * @brief AES image encryption tool supporting BMP, PNG, and JPEG formats.
  *
- * This program is a generalisation of bmp_encryptor. It encrypts or decrypts
- * image files using AES in ECB, CBC, OFB, or CTR mode, dispatching to the
- * correct File::FileBase subclass based on the input file extension.
+ * This program encrypts or decrypts image files using AES in ECB, CBC, OFB,
+ * or CTR mode, dispatching to the correct File::FileBase subclass based on
+ * the input file extension.
  *
  * Round-trip fidelity by format:
  *   BMP  — lossless container; encrypt → decrypt restores the original exactly.
@@ -13,10 +13,10 @@
  *          The program warns the user before proceeding.
  *
  * Usage:
- *   Encryption:     image_encryptor --encrypt --key <file> --input <img>
- *                       --output <img> [--mode ECB|CBC|OFB|CTR]
+ *   Encryption:     image_encryptor --key <file> --input <img> --output <img>
+ *                       [--mode ECB|CBC|OFB|CTR] [--iv <32 hex chars>]
  *   Decryption:     image_encryptor --decrypt --key <file> --input <img>
- *                       --output <img> --mode-data <file>
+ *                       --output <img> --iv <32 hex chars>
  *   Key generation: image_encryptor --generate-key --key-length <bits>
  *                       --output <file>
  */
@@ -26,71 +26,158 @@
 #include "../../cli-tools/include/cli_config.hpp"
 
 #include <iostream>
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
+#include <vector>
 
 using namespace CipherFortis;
 using namespace CLIConfig;
 using namespace File;
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static std::vector<uint8_t> parse_hex_iv(const std::string& hex) {
+    if (hex.size() != 32)
+        throw std::invalid_argument("IV must be exactly 32 hex characters (16 bytes)");
+    std::vector<uint8_t> iv(16);
+    for (size_t i = 0; i < 16; ++i) {
+        unsigned int byte;
+        std::istringstream ss(hex.substr(i * 2, 2));
+        if (!(ss >> std::hex >> byte))
+            throw std::invalid_argument("Invalid hex in IV: " + hex);
+        iv[i] = static_cast<uint8_t>(byte);
+    }
+    return iv;
+}
+
+static std::string bytes_to_hex(const uint8_t* data, size_t len) {
+    std::ostringstream oss;
+    for (size_t i = 0; i < len; ++i)
+        oss << std::hex << std::uppercase << std::setfill('0') << std::setw(2)
+            << static_cast<unsigned>(data[i]);
+    return oss.str();
+}
+
+static bool mode_needs_iv(Cipher::OperationMode::Identifier m) {
+    return m != Cipher::OperationMode::Identifier::ECB;
+}
+
 // ── ImageCryptoConfig ─────────────────────────────────────────────────────────
 
-/**
- * @class ImageCryptoConfig
- * @brief Thin FileCryptoConfig subclass for the multi-format image encryptor.
- *
- * The only additions over the base class are:
- *   - A customised help text that names the supported formats.
- *   - A JPEG lossy-codec warning emitted during validate().
- *
- * All validation logic and factory methods (create_key, create_optmode)
- * are inherited unchanged from FileCryptoConfig.
- */
-class ImageCryptoConfig : public CLIConfig::FileCryptoConfig {
+class ImageCryptoConfig : public CLIConfig::BaseCryptoConfig {
 public:
-    bool validate(const CLIConfig::ArgumentParser& parser) override {
-        if (!FileCryptoConfig::validate(parser)) return false;
+    bool validate(const CLIConfig::ArgumentParser& parser) override;
+    void print_help(const CLIConfig::ArgumentParser& parser) const;
 
-        // Warn the user when the input is a JPEG and the operation is
-        // encrypt or decrypt — the lossy codec will corrupt the encrypted
-        // bytes on re-encode, so decryption cannot recover the original.
-        if (operation != Operation::GENERATE_KEY && image_is_lossy(input_file)) {
-            std::cerr
-                << "Warning: '" << input_file.filename().string() << "' is a JPEG.\n"
-                << "  JPEG uses lossy compression. Encrypted bytes will be altered\n"
-                << "  by the codec on save, so decryption will NOT restore the\n"
-                << "  original image. The visual encryption effect is still visible.\n"
-                << "  Use BMP or PNG for a lossless round-trip.\n\n";
+    bool        decrypt      = false;
+    bool        generate_key = false;
+    std::string key_file, input_file, output_file, iv_hex;
+    Key::LengthBits                   key_length     = Key::LengthBits::_128;
+    Cipher::OperationMode::Identifier operation_mode = Cipher::OperationMode::Identifier::CBC;
+};
+
+bool ImageCryptoConfig::validate(const CLIConfig::ArgumentParser& parser) {
+    if (parser.has("--help")) {
+        print_help(parser);
+        is_valid = false;
+        return false;
+    }
+
+    generate_key = parser.has("--generate-key");
+    decrypt      = parser.has("--decrypt");
+    iv_hex       = parser.getOr("--iv", "");
+
+    // Key length
+    std::string kl_str = parser.getOr("--key-length", "128");
+    if      (kl_str == "128") key_length = Key::LengthBits::_128;
+    else if (kl_str == "192") key_length = Key::LengthBits::_192;
+    else if (kl_str == "256") key_length = Key::LengthBits::_256;
+    else {
+        error_message = "Invalid key length: " + kl_str + ". Use 128, 192, or 256.";
+        is_valid = false;
+        return false;
+    }
+
+    // Operation mode
+    std::string mode_str = parser.getOr("--mode", "CBC");
+    if      (mode_str == "ECB") operation_mode = Cipher::OperationMode::Identifier::ECB;
+    else if (mode_str == "CBC") operation_mode = Cipher::OperationMode::Identifier::CBC;
+    else if (mode_str == "OFB") operation_mode = Cipher::OperationMode::Identifier::OFB;
+    else if (mode_str == "CTR") operation_mode = Cipher::OperationMode::Identifier::CTR;
+    else {
+        error_message = "Invalid mode: " + mode_str + ". Use ECB, CBC, OFB, or CTR.";
+        is_valid = false;
+        return false;
+    }
+
+    if (generate_key) {
+        output_file = parser.getOr("--output", "");
+        if (output_file.empty()) {
+            error_message = "Missing required argument: --output";
+            is_valid = false;
+            return false;
         }
-
+        is_valid = true;
         return true;
     }
 
-    void print_help(const CLIConfig::ArgumentParser& parser) const override {
-        const char* prog = parser.program_name();
-        std::cout
-            << prog << " — AES Image Encryption Tool\n"
-            << "Supported formats: BMP, PNG, JPEG (.jpg / .jpeg)\n\n"
-            << "Usage:\n"
-            << "  Encryption:     " << prog
-                << " --encrypt --key <keyfile> --input <img> --output <img> [options]\n"
-            << "  Decryption:     " << prog
-                << " --decrypt --key <keyfile> --input <img> --output <img>"
-                << " --mode-data <file> [options]\n"
-            << "  Key generation: " << prog
-                << " --generate-key --key-length <bits> --output <file>\n\n"
-            << "Options:\n"
-            << "  --key-length <bits>        Key length in bits: 128, 192, or 256 (default: 128)\n"
-            << "  --mode <ECB|CBC|OFB|CTR>   Operation mode (default: CBC)\n"
-            << "  --mode-data <file>         Saved operation-mode data (IV/counter);\n"
-            << "                             required for decryption in CBC, OFB, CTR\n"
-            << "  --help                     Show this help message\n\n"
-            << "Notes:\n"
-            << "  BMP and PNG support lossless round-trips (encrypt then decrypt\n"
-            << "  recovers the original). JPEG is lossy: decryption will not\n"
-            << "  restore the original image.\n";
+    // Encrypt / decrypt path
+    key_file    = parser.getOr("--key",    "");
+    input_file  = parser.getOr("--input",  "");
+    output_file = parser.getOr("--output", "");
+
+    for (auto& [name, val] : std::vector<std::pair<std::string, std::string>>{
+            {"--key", key_file}, {"--input", input_file}, {"--output", output_file}}) {
+        if (val.empty()) {
+            error_message = "Missing required argument: " + name;
+            is_valid = false;
+            return false;
+        }
     }
-};
+
+    // Warn if the input is a JPEG
+    if (image_is_lossy(input_file)) {
+        std::cerr
+            << "Warning: '" << std::filesystem::path(input_file).filename().string()
+            << "' is a JPEG.\n"
+            << "  JPEG uses lossy compression. Encrypted bytes will be altered\n"
+            << "  by the codec on save, so decryption will NOT restore the\n"
+            << "  original image. The visual encryption effect is still visible.\n"
+            << "  Use BMP or PNG for a lossless round-trip.\n\n";
+    }
+
+    is_valid = true;
+    return true;
+}
+
+void ImageCryptoConfig::print_help(const CLIConfig::ArgumentParser& parser) const {
+    const char* prog = parser.program_name();
+    std::cout
+        << prog << " — AES Image Encryption Tool\n"
+        << "Supported formats: BMP, PNG, JPEG (.jpg / .jpeg)\n\n"
+        << "Usage:\n"
+        << "  Encryption:     " << prog
+            << " --key <keyfile> --input <img> --output <img> [options]\n"
+        << "  Decryption:     " << prog
+            << " --decrypt --key <keyfile> --input <img> --output <img>"
+            << " --iv <hex> [options]\n"
+        << "  Key generation: " << prog
+            << " --generate-key --key-length <bits> --output <file>\n\n"
+        << "Options:\n"
+        << "  --decrypt                  Decrypt instead of encrypt (default: encrypt)\n"
+        << "  --key-length <bits>        Key length in bits: 128, 192, or 256 (default: 128)\n"
+        << "  --mode <ECB|CBC|OFB|CTR>   Operation mode (default: CBC)\n"
+        << "  --iv <32 hex chars>        16-byte IV as 32 hex characters (CBC/OFB/CTR);\n"
+        << "                             if omitted on encrypt, a random IV is generated\n"
+        << "                             and printed to stdout\n"
+        << "  --help                     Show this help message\n\n"
+        << "Notes:\n"
+        << "  BMP and PNG support lossless round-trips (encrypt then decrypt\n"
+        << "  recovers the original). JPEG is lossy: decryption will not\n"
+        << "  restore the original image.\n";
+}
 
 // ── main ──────────────────────────────────────────────────────────────────────
 
@@ -113,7 +200,7 @@ int main(int argc, const char* argv[]) {
 
     try {
         // ── Key generation ────────────────────────────────────────────────────
-        if (config.operation == ImageCryptoConfig::Operation::GENERATE_KEY) {
+        if (config.generate_key) {
             Key key(config.key_length);
             key.save(config.output_file.c_str());
             std::cout << "Key saved to: " << config.output_file << "\n";
@@ -121,29 +208,33 @@ int main(int argc, const char* argv[]) {
         }
 
         // ── Encrypt / Decrypt ─────────────────────────────────────────────────
-        std::unique_ptr<FileBase> image = make_image(config.input_file);
-        Cipher::OperationMode optmode  = config.create_optmode();
-        Cipher cipher(config.create_key(), optmode);
+        Key key(config.key_file.c_str());
+        Cipher::OperationMode optmode(config.operation_mode);
 
+        if (!config.iv_hex.empty()) {
+            optmode.setInitialVector(parse_hex_iv(config.iv_hex));
+        } else if (mode_needs_iv(config.operation_mode)) {
+            // Auto-generated IV: print it so the user can reuse it for decryption
+            const uint8_t* iv_ptr = optmode.getIVpointerData();
+            std::cout << "Generated IV (save for decryption): "
+                      << bytes_to_hex(iv_ptr, 16) << "\n";
+        }
+
+        std::unique_ptr<FileBase> image = make_image(config.input_file);
+        Cipher cipher(key, optmode);
         image->load();
 
-        if (config.operation == ImageCryptoConfig::Operation::ENCRYPT) {
-            image->apply_encryption(cipher);
-            std::cout << "Encrypted: " << config.input_file
-                      << " -> "        << config.output_file << "\n";
-        } else {
+        if (config.decrypt) {
             image->apply_decryption(cipher);
             std::cout << "Decrypted: " << config.input_file
+                      << " -> "        << config.output_file << "\n";
+        } else {
+            image->apply_encryption(cipher);
+            std::cout << "Encrypted: " << config.input_file
                       << " -> "        << config.output_file << "\n";
         }
 
         image->save(config.output_file);
-
-        // Save operation-mode data (IV / counter) when not loaded from file,
-        // so the user has everything needed for a later decryption call.
-        if (config.mode_file.empty()) {
-            optmode.save(config.output_file.string() + ".optmode");
-        }
 
     } catch (const std::invalid_argument& e) {
         std::cerr << "Error: " << e.what() << "\n";

--- a/command-line-tools/image-encryption/image_encryptor.cpp
+++ b/command-line-tools/image-encryption/image_encryptor.cpp
@@ -25,6 +25,7 @@
 #include "../../file-handlers/include/image_factory.hpp"
 #include "../../cli-tools/include/cli_config.hpp"
 
+#include <fstream>
 #include <iostream>
 #include <iomanip>
 #include <memory>
@@ -73,7 +74,7 @@ public:
 
     bool        decrypt      = false;
     bool        generate_key = false;
-    std::string key_file, input_file, output_file, iv_hex;
+    std::string key_file, input_file, output_file, iv_hex, metadata_file;
     Key::LengthBits                   key_length     = Key::LengthBits::_128;
     Cipher::OperationMode::Identifier operation_mode = Cipher::OperationMode::Identifier::CBC;
 };
@@ -85,9 +86,10 @@ bool ImageCryptoConfig::validate(const CLIConfig::ArgumentParser& parser) {
         return false;
     }
 
-    generate_key = parser.has("--generate-key");
-    decrypt      = parser.has("--decrypt");
-    iv_hex       = parser.getOr("--iv", "");
+    generate_key  = parser.has("--generate-key");
+    decrypt       = parser.has("--decrypt");
+    iv_hex        = parser.getOr("--iv", "");
+    metadata_file = parser.getOr("--metadata", "");
 
     // Key length
     std::string kl_str = parser.getOr("--key-length", "128");
@@ -161,11 +163,43 @@ void ImageCryptoConfig::print_help(const CLIConfig::ArgumentParser& parser) cons
         << "  --iv <32 hex chars>        16-byte IV as 32 hex characters (CBC/OFB/CTR);\n"
         << "                             if omitted on encrypt, a random IV is generated\n"
         << "                             and printed to stdout\n"
+        << "  --metadata <file>          JSON file to save IV+mode on encrypt,\n"
+        << "                             or load IV+mode on decrypt (replaces --iv)\n"
         << "  --help                     Show this help message\n\n"
         << "Notes:\n"
         << "  BMP and PNG support lossless round-trips (encrypt then decrypt\n"
         << "  recovers the original). JPEG will be saved as PNG (lossless)\n"
         << "  to preserve encrypted pixels.\n";
+}
+
+// ── Metadata helpers ──────────────────────────────────────────────────────────
+
+static void write_metadata(const std::string& path,
+                            const std::string& mode, const std::string& iv_hex) {
+    std::ofstream f(path);
+    if (!f) throw std::runtime_error("Cannot open metadata file for writing: " + path);
+    f << "{\n  \"mode\": \"" << mode << "\"";
+    if (!iv_hex.empty())
+        f << ",\n  \"iv\": \"" << iv_hex << "\"";
+    f << "\n}\n";
+}
+
+static void read_metadata(const std::string& path,
+                           std::string& mode, std::string& iv_hex) {
+    std::ifstream f(path);
+    if (!f) throw std::runtime_error("Cannot open metadata file: " + path);
+    std::string content((std::istreambuf_iterator<char>(f)),
+                         std::istreambuf_iterator<char>());
+    auto extract = [&](const std::string& key) -> std::string {
+        std::string search = "\"" + key + "\": \"";
+        auto pos = content.find(search);
+        if (pos == std::string::npos) return "";
+        pos += search.size();
+        auto end = content.find("\"", pos);
+        return (end != std::string::npos) ? content.substr(pos, end - pos) : "";
+    };
+    mode   = extract("mode");
+    iv_hex = extract("iv");
 }
 
 // ── main ──────────────────────────────────────────────────────────────────────
@@ -197,6 +231,17 @@ int main(int argc, const char* argv[]) {
         }
 
         // ── Encrypt / Decrypt ─────────────────────────────────────────────────
+
+        // Load metadata before optmode creation so mode/IV override takes effect
+        if (config.decrypt && !config.metadata_file.empty()) {
+            std::string mode_str, iv_from_meta;
+            read_metadata(config.metadata_file, mode_str, iv_from_meta);
+            if (!mode_str.empty())
+                config.operation_mode = Cipher::OperationMode::string_to_identifier(mode_str);
+            if (config.iv_hex.empty())
+                config.iv_hex = iv_from_meta;
+        }
+
         Key key(config.key_file.c_str());
         Cipher::OperationMode optmode(config.operation_mode);
 
@@ -231,6 +276,15 @@ int main(int argc, const char* argv[]) {
         }
 
         image->save(config.output_file);
+
+        if (!config.decrypt && !config.metadata_file.empty()) {
+            std::string iv_hex_out;
+            if (mode_needs_iv(config.operation_mode))
+                iv_hex_out = bytes_to_hex(optmode.getIVpointerData(), 16);
+            write_metadata(config.metadata_file,
+                           Cipher::OperationMode::identifier_to_string(config.operation_mode),
+                           iv_hex_out);
+        }
 
     } catch (const std::invalid_argument& e) {
         std::cerr << "Error: " << e.what() << "\n";

--- a/file-handlers/src/jpeg_image.cpp
+++ b/file-handlers/src/jpeg_image.cpp
@@ -16,13 +16,24 @@ void JPEG::save(const std::filesystem::path& output_path) const {
         );
     }
     const auto& out = output_path.empty() ? this->file_path : output_path;
-    int result = stbi_write_jpg(
-        out.string().c_str(),
-        width_, height_, channels_,
-        this->data.data(),
-        quality_);
-    if (!result)
-        throw std::runtime_error("JPEG::save(): failed to write file");
+    int result;
+    if (out.extension() == ".png") {
+        result = stbi_write_png(
+            out.string().c_str(),
+            width_, height_, channels_,
+            this->data.data(),
+            width_ * channels_);
+        if (!result)
+            throw std::runtime_error("JPEG::save(): failed to write PNG file");
+    } else {
+        result = stbi_write_jpg(
+            out.string().c_str(),
+            width_, height_, channels_,
+            this->data.data(),
+            quality_);
+        if (!result)
+            throw std::runtime_error("JPEG::save(): failed to write file");
+    }
 }
 
 } // namespace File

--- a/file-handlers/src/png_image.cpp
+++ b/file-handlers/src/png_image.cpp
@@ -16,13 +16,25 @@ void PNG::save(const std::filesystem::path& output_path) const {
         );
     }
     const auto& out = output_path.empty() ? this->file_path : output_path;
-    int result = stbi_write_png(
-        out.string().c_str(),
-        width_, height_, channels_,
-        this->data.data(),
-        width_ * channels_);
-    if (!result)
-        throw std::runtime_error("PNG::save(): failed to write file");
+    const std::string ext = out.extension().string();
+    int result;
+    if (ext == ".jpg" || ext == ".jpeg") {
+        result = stbi_write_jpg(
+            out.string().c_str(),
+            width_, height_, channels_,
+            this->data.data(),
+            90);
+        if (!result)
+            throw std::runtime_error("PNG::save(): failed to write JPEG file");
+    } else {
+        result = stbi_write_png(
+            out.string().c_str(),
+            width_, height_, channels_,
+            this->data.data(),
+            width_ * channels_);
+        if (!result)
+            throw std::runtime_error("PNG::save(): failed to write file");
+    }
 }
 
 } // namespace File

--- a/tests/include/raster_image_fixture.hpp
+++ b/tests/include/raster_image_fixture.hpp
@@ -10,6 +10,7 @@ class RasterImageFixture : public ::testing::Test {
 public:
     static void createValidPng(const fs::path& path, int width, int height);
     static void createValidBmp(const fs::path& path, int width, int height);
+    static void createValidJpeg(const fs::path& path, int width, int height, int quality = 90);
 
 protected:
     fs::path testDataDir     = fs::path("tests/data/raster_image");
@@ -29,7 +30,6 @@ private:
     void cleanupTestEnvironment();
     void createCorruptFile(const fs::path& path);
     void createEmptyFile(const fs::path& path);
-    void createValidJpeg(const fs::path& path, int width, int height, int quality = 90);
 };
 
 #endif // RASTER_IMAGE_FIXTURE_HPP

--- a/tests/include/system_workflows.hpp
+++ b/tests/include/system_workflows.hpp
@@ -63,6 +63,9 @@ public:
 
 	// SYSTEM TEST 3: Performance and Large File Handling
 	bool test_large_file_performance();
+
+	// SYSTEM TEST 4: JPEG encryption saves output as PNG
+	bool test_jpeg_encryption_saves_as_png();
 }; // class SystemTests
 
 } // namespace CommandLineToolsTest

--- a/tests/include/system_workflows.hpp
+++ b/tests/include/system_workflows.hpp
@@ -66,6 +66,9 @@ public:
 
 	// SYSTEM TEST 4: JPEG encryption saves output as PNG
 	bool test_jpeg_encryption_saves_as_png();
+
+	// SYSTEM TEST 5: Metadata round-trip (encrypt with --metadata, decrypt with --metadata)
+	bool test_metadata_round_trip();
 }; // class SystemTests
 
 } // namespace CommandLineToolsTest

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -384,6 +384,62 @@ bool SystemTests::test_jpeg_encryption_saves_as_png() {
     return success;
 }
 
+// SYSTEM TEST 5: Metadata round-trip
+bool SystemTests::test_metadata_round_trip() {
+    bool success = true;
+
+    const fs::path metaPath    = this->testDataDir / "meta.json";
+    const fs::path encryptedPath = testDataDir / ("meta_enc." + SystemUtils::toFileExtension(ff_));
+    const fs::path decryptedPath = testDataDir / ("meta_dec." + SystemUtils::toFileExtension(ff_));
+
+    // Generate key
+    std::string gen_key_cmd =
+        this->executable_path + " --generate-key --output " + this->keyPath.string();
+    SystemUtils::execute_cli_command(gen_key_cmd);
+
+    // Encrypt with --metadata (no --iv; random IV generated and saved to JSON)
+    std::string encrypt_cmd =
+        this->executable_path + " --key " + this->keyPath.string() +
+        " --input " + this->originalValidPath.string() +
+        " --output " + encryptedPath.string() +
+        " --metadata " + metaPath.string();
+    int enc_result = SystemUtils::execute_cli_command(encrypt_cmd);
+    EXPECT_EQ(0, enc_result) << "Metadata encrypt should succeed";
+    success &= (enc_result == 0);
+
+    bool metaCreated = fs::exists(metaPath);
+    EXPECT_TRUE(metaCreated) << "Metadata JSON file should be created";
+    success &= metaCreated;
+
+    bool encCreated = fs::exists(encryptedPath);
+    EXPECT_TRUE(encCreated) << "Encrypted file should be created";
+    success &= encCreated;
+
+    // Decrypt with --metadata (no --iv; IV and mode loaded from JSON)
+    std::string decrypt_cmd =
+        this->executable_path + " --decrypt --key " + this->keyPath.string() +
+        " --input " + encryptedPath.string() +
+        " --output " + decryptedPath.string() +
+        " --metadata " + metaPath.string();
+    int dec_result = SystemUtils::execute_cli_command(decrypt_cmd);
+    EXPECT_EQ(0, dec_result) << "Metadata decrypt should succeed";
+    success &= (dec_result == 0);
+
+    bool decCreated = fs::exists(decryptedPath);
+    EXPECT_TRUE(decCreated) << "Decrypted file should be created";
+    success &= decCreated;
+
+    if (decCreated) {
+        std::vector<uint8_t> original  = SystemUtils::read_file(this->originalValidPath, true);
+        std::vector<uint8_t> decrypted = SystemUtils::read_file(decryptedPath, true);
+        bool contentMatches = (original == decrypted);
+        EXPECT_TRUE(contentMatches) << "Decrypted content should match original";
+        success &= contentMatches;
+    }
+
+    return success;
+}
+
 // SYSTEM TEST 3: Performance and Large File Handling
 bool SystemTests::test_large_file_performance() {
     bool success = true;

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -331,6 +331,59 @@ bool SystemTests::test_error_scenarios() {
     return success;
 }
 
+// SYSTEM TEST 4: JPEG encryption saves output as PNG
+bool SystemTests::test_jpeg_encryption_saves_as_png() {
+    bool success = true;
+
+    // Generate key
+    std::string gen_key_cmd =
+        this->executable_path + " --generate-key --output " +
+        this->keyPath.string();
+    SystemUtils::execute_cli_command(gen_key_cmd);
+
+    // Create a JPEG input
+    const fs::path jpegInput  = this->testDataDir / "jpeg_input.jpg";
+    const fs::path encJpg     = this->testDataDir / "enc.jpg";
+    const fs::path encPng     = this->testDataDir / "enc.png";
+    const fs::path decJpg     = this->testDataDir / "dec.jpg";
+
+    RasterImageFixture::createValidJpeg(jpegInput, 32, 32);
+
+    // Encrypt — tool should redirect output to enc.png
+    std::string encrypt_cmd =
+        this->executable_path + " --key " + this->keyPath.string() +
+        " --input " + jpegInput.string() +
+        " --output " + encJpg.string() +
+        " --iv 00112233445566778899AABBCCDDEEFF";
+    int enc_result = SystemUtils::execute_cli_command(encrypt_cmd);
+    EXPECT_EQ(0, enc_result) << "JPEG encryption should succeed";
+    success &= (enc_result == 0);
+
+    bool pngCreated = fs::exists(encPng);
+    EXPECT_TRUE(pngCreated) << "Encrypted output should be saved as .png";
+    success &= pngCreated;
+
+    bool jpgNotCreated = !fs::exists(encJpg);
+    EXPECT_TRUE(jpgNotCreated) << "No .jpg output should be created";
+    success &= jpgNotCreated;
+
+    // Decrypt the PNG back to JPEG
+    std::string decrypt_cmd =
+        this->executable_path + " --decrypt --key " + this->keyPath.string() +
+        " --input " + encPng.string() +
+        " --output " + decJpg.string() +
+        " --iv 00112233445566778899AABBCCDDEEFF";
+    int dec_result = SystemUtils::execute_cli_command(decrypt_cmd);
+    EXPECT_EQ(0, dec_result) << "Decryption of PNG to JPEG should succeed";
+    success &= (dec_result == 0);
+
+    bool decCreated = fs::exists(decJpg);
+    EXPECT_TRUE(decCreated) << "Decrypted JPEG should be created";
+    success &= decCreated;
+
+    return success;
+}
+
 // SYSTEM TEST 3: Performance and Large File Handling
 bool SystemTests::test_large_file_performance() {
     bool success = true;

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -186,9 +186,10 @@ bool SystemTests::test_file_encryption_workflow() {
 
     // Step 3: Encrypt the file
     std::string encrypt_cmd =
-        this->executable_path + " --encrypt --mode CBC --key " +
+        this->executable_path + " --mode CBC --key " +
         this->keyPath.string() + " --input " + this->originalValidPath.string()
-        + " --output " + this->encryptedOriginalValidPath.string();
+        + " --output " + this->encryptedOriginalValidPath.string()
+        + " --iv 00112233445566778899AABBCCDDEEFF";
     int result2 = SystemUtils::execute_cli_command(
         encrypt_cmd
     );
@@ -217,7 +218,7 @@ bool SystemTests::test_file_encryption_workflow() {
         this->executable_path + " --decrypt --mode CBC --key " + this->keyPath.string() +
         " --input " + this->encryptedOriginalValidPath.string() +
         " --output " + this->decryptedOriginalValidPath.string() +
-        " --mode-data " + this->encryptedOriginalValidPath.string() + ".optmode";
+        " --iv 00112233445566778899AABBCCDDEEFF";
     int result3 = SystemUtils::execute_cli_command(
         decrypt_cmd
     );
@@ -278,7 +279,7 @@ bool SystemTests::test_error_scenarios() {
 
     // Encrypt with key1
     std::string encrypt_cmd =
-        this->executable_path + " --encrypt --key " + this->keyPath.string() +
+        this->executable_path + " --key " + this->keyPath.string() +
         " --input " + this->originalValidPath.string() +
         " --output " + this->encryptedOriginalValidPath.string();
     bool encryptSucceeded = (SystemUtils::execute_cli_command(encrypt_cmd) == 0);
@@ -312,7 +313,7 @@ bool SystemTests::test_error_scenarios() {
 
     // Test 2: Non-existent file
     int nonexistent_result = SystemUtils::execute_cli_command(
-        this->executable_path + " --encrypt --input " +
+        this->executable_path + " --input " +
         this->nonexistentPath.string() + " --output nonexistent_out.bin"
     );
     bool nonexistentFails = (nonexistent_result != 0);
@@ -321,7 +322,7 @@ bool SystemTests::test_error_scenarios() {
 
     // Test 3: Invalid key file
     int invalid_key_result = SystemUtils::execute_cli_command(
-        this->executable_path + " --encrypt --key invalid.key --input " + this->originalValidPath.string() + " --output out.aes"
+        this->executable_path + " --key invalid.key --input " + this->originalValidPath.string() + " --output out.aes"
     );
     bool invalidKeyFails = (invalid_key_result != 0);
     EXPECT_TRUE(invalidKeyFails) << "Using invalid key file should fail";
@@ -340,9 +341,10 @@ bool SystemTests::test_large_file_performance() {
     );
 
 
-    std::string encrypt_cmd = this->executable_path + " --encrypt --mode CBC --key " + this->keyPath.string() +
+    std::string encrypt_cmd = this->executable_path + " --mode CBC --key " + this->keyPath.string() +
         " --input " + this->originalLargePath.string() +
-        " --output " + this->encryptedOriginalLargePath.string();
+        " --output " + this->encryptedOriginalLargePath.string() +
+        " --iv 00112233445566778899AABBCCDDEEFF";
 
     // Time the encryption
     auto start_time = std::chrono::high_resolution_clock::now();
@@ -368,7 +370,7 @@ bool SystemTests::test_large_file_performance() {
         " --decrypt --mode CBC --key " + this->keyPath.string() +
         " --input " + this->encryptedOriginalLargePath.string() +
         " --output " + this->decryptedOriginalLargePath.string() +
-        " --mode-data " + this->encryptedOriginalLargePath.string() + ".optmode";
+        " --iv 00112233445566778899AABBCCDDEEFF";
 
     // Time the decryption
     auto decrypt_start = std::chrono::high_resolution_clock::now();

--- a/tests/system/test_image_encryptorcpp.cpp
+++ b/tests/system/test_image_encryptorcpp.cpp
@@ -19,3 +19,8 @@ TEST(SystemTest, LargeFilePerformance) {
     cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, cltt::FileFormat::BITMAP);
     EXPECT_TRUE(st.test_large_file_performance());
 }
+
+TEST(SystemTest, JpegEncryptSavesAsPng) {
+    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, cltt::FileFormat::BITMAP);
+    EXPECT_TRUE(st.test_jpeg_encryption_saves_as_png());
+}

--- a/tests/system/test_image_encryptorcpp.cpp
+++ b/tests/system/test_image_encryptorcpp.cpp
@@ -24,3 +24,8 @@ TEST(SystemTest, JpegEncryptSavesAsPng) {
     cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, cltt::FileFormat::BITMAP);
     EXPECT_TRUE(st.test_jpeg_encryption_saves_as_png());
 }
+
+TEST(SystemTest, MetadataRoundTrip) {
+    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, cltt::FileFormat::BITMAP);
+    EXPECT_TRUE(st.test_metadata_round_trip());
+}


### PR DESCRIPTION
# Summary

This branch extends the image encryption tooling across three areas:

## JPEG / PNG cross-format save support

- jpeg_image: saves as PNG when the output extension is .png (preserves encrypted pixels losslessly).
- png_image: saves as JPEG when the output extension is .jpg/.jpeg.
- image_encryptor: automatically redirects JPEG encrypt output to .png to avoid lossy re-encoding of encrypted data.

## Image_encryptor UX redesign

Redesigned the CLI interface to match the style of hsm_encrypt: flags-based invocation, consistent error output, and a --generate-key sub-command. Existing system tests were updated to reflect the new interface.

## --metadata flag for self-contained encrypt/decrypt round-trips                                                                    

Both image_encryptor and hsm_encrypt now support --metadata <file>, which saves the operation mode and IV to a human-readable JSON file on encrypt and loads them back on decrypt — eliminating the need to manually copy-paste the IV between invocations.

JSON format:
{ "mode": "CBC", "iv": "00112233445566778899AABBCCDDEEFF" }

FileCryptoConfig was also cleaned up: the internal field mode_file and CLI flag --mode-data are renamed to metadata_file / --metadata for consistency.

## Test plan

- SystemTest/FileEncryptionWorkflow — basic BMP encrypt/decrypt round-trip
- SystemTest/ErrorScenarios — wrong key, missing file, invalid key file
- SystemTest/LargeFilePerformance — 12 MB BMP within 10 s
- SystemTest/JpegEncryptSavesAsPng — JPEG input redirected to .png, decrypt back to .jpg
- SystemTest/MetadataRoundTrip — encrypt with --metadata, decrypt with --metadata, byte-exact match

# Commits

- **refactor(image-encryptor): redesign UX to match hsm_encrypt**
- **test(system-workflows): update commands for new image-encryptor UX**
- **feat(jpeg-image): save as PNG when output extension is .png**
- **feat(png-image): save as JPEG when output extension is .jpg or .jpeg**
- **feat(image-encryptor): redirect JPEG encrypt output to PNG, remove stale warning**
- **refactor(raster-image-fixture): expose createValidJpeg as public static**
- **feat(system-workflows): add test_jpeg_encryption_saves_as_png**
- **test(image-encryptor): add JpegEncryptSavesAsPng test case**
- **refactor(cli-config): rename mode_file field to metadata_file**
- **feat(cli-config): rename --mode-data flag to --metadata**
- **feat(image-encryptor): add --metadata flag for IV/mode round-trip**
- **feat(hsm-encrypt): add --metadata flag for IV/mode round-trip**
- **feat(system-workflows): declare test_metadata_round_trip**
- **feat(system-workflows): add test_metadata_round_trip**
- **test(image-encryptor): add MetadataRoundTrip test case**
