### PR TITLE
refactor(core-crypto): cut metadata from key saving and load

### DIFF
--- a/core-crypto/include/key.hpp
+++ b/core-crypto/include/key.hpp
@@ -31,9 +31,10 @@ public:
 	 * */
 	Key(const std::vector<uint8_t>& key_, LengthBits);
 	/*
-	 * Consider: Throws exception when file does not exist or when file is not valid
+	 * Consider: Throws exception when file does not exist, cannot be opened, or
+	 * its size does not match a valid AES key length (16, 24, or 32 bytes).
 	 * */
-	explicit Key(const std::string& filepath);						// -Building from binary file.
+	explicit Key(const std::string& filepath);						// -Building from raw binary file.
 	Key(const Key&);
 	~Key();
 

--- a/core-crypto/src/core/key.cpp
+++ b/core-crypto/src/core/key.cpp
@@ -48,47 +48,39 @@ Key::Key(const Key& k): lenBits(k.lenBits), lenBytes(k.lenBytes) {
     for(i = 0; i < k.lenBytes; i++) this->data[i] = k.data[i];                  // -Supposing Cipher object is well constructed, this is, k.data != nullptr
 }
 
-constexpr static const char* keyFileHeaderID = "AESKEY";
-constexpr const size_t headerLen = 6;
-
 Key::Key(const std::string& filepath): lenBits(LengthBits::_128), lenBytes(BLOCK_SIZE) {
-    char headerID[headerLen];
-    uint16_t keyLen;
     std::ifstream file;
-    file.open(filepath, std::ios::binary);
-    if(file.is_open()) {
-        file.read(const_cast<char*>(headerID), static_cast<std::streamsize>(headerLen)); // -Determining if file is a .data file
-        if(memcmp(headerID, "AESKEY", headerLen) == 0) {
-                file.read(reinterpret_cast<char*>(&keyLen), 2);                                   // -Reading key lenBits
-                if(keyLen == uint16_t(LengthBits::_128) || keyLen == uint16_t(LengthBits::_192) || keyLen == uint16_t(LengthBits::_256))
-                    this->lenBits = static_cast<LengthBits>(keyLen);
-                else {
-                    throw std::runtime_error(
-                        "In file src/core/key.cpp, function Key::Key(const std::string& filepath):"
-                        + std::to_string(static_cast<int>(keyLen)) + " is not a valid length (in bits) for key.\n"
-                    );
-                }
-                this->lenBytes = fromLenBitsToLenBytes(this->lenBits);          // -lenBytes = lenbits / 8;
-                this->data = new uint8_t[this->lenBytes];                       // -Reading key
-                file.read(reinterpret_cast<char*>(this->data), static_cast<std::streamsize>(this->lenBytes));
-                if (!file || file.gcount() != static_cast<std::streamsize>(this->lenBytes)) {
-                    delete[] this->data;
-                    this->data = nullptr;
-                    throw std::runtime_error(
-                        "In file src/core/key.cpp, function Key::Key(const std::string& filepath): "
-                        "File is truncated or corrupted. Expected " + std::to_string(this->lenBytes) +
-                        " bytes of key data, but could only read " + std::to_string(file.gcount()) + " bytes.\n"
-                    );
-                }
-           } else {
-                throw std::runtime_error(
-                    "In file src/core/key.cpp, function Key::Key(const std::string& filepath): String "
-                    + filepath + " does not represent a valid AES key file.\n"
-                );
-           }
-    } else {
+    file.open(filepath, std::ios::binary | std::ios::ate);
+    if(!file.is_open()) {
         throw std::runtime_error(
-            "In file src/core/key.cpp, function Key::Key(const std::string& filepath): Failed to open " + filepath
+            "In file src/core/key.cpp, function Key::Key(const std::string& filepath):"
+            " Failed to open " + filepath
+        );
+    }
+    std::streamsize fileSize = file.tellg();
+    if(fileSize == 16)
+        this->lenBits = LengthBits::_128;
+    else if(fileSize == 24)
+        this->lenBits = LengthBits::_192;
+    else if(fileSize == 32)
+        this->lenBits = LengthBits::_256;
+    else {
+        throw std::invalid_argument(
+            "In file src/core/key.cpp, function Key::Key(const std::string& filepath):"
+            " File size " + std::to_string(fileSize) +
+            " does not match any valid AES key length (16, 24, or 32 bytes)."
+        );
+    }
+    this->lenBytes = fromLenBitsToLenBytes(this->lenBits);
+    this->data = new uint8_t[this->lenBytes];
+    file.seekg(0);
+    file.read(reinterpret_cast<char*>(this->data), static_cast<std::streamsize>(this->lenBytes));
+    if(!file || file.gcount() != static_cast<std::streamsize>(this->lenBytes)) {
+        delete[] this->data;
+        this->data = nullptr;
+        throw std::runtime_error(
+            "In file src/core/key.cpp, function Key::Key(const std::string& filepath):"
+            " Failed to read key data from " + filepath
         );
     }
 }
@@ -143,20 +135,20 @@ std::ostream& CipherFortis::operator<<(std::ostream& ost, const Key& k) {
 void Key::save(const std::string& filepath) const {
     std::ofstream file;
     file.open(filepath, std::ios::binary);
-    if(file.is_open()) {
-        file.write(keyFileHeaderID, headerLen);                                                 // -File type
-        file.write(reinterpret_cast<const char*>(&this->lenBits), 2);           // -Key lenBits in bits
-        file.write(reinterpret_cast<char*>(this->data), static_cast<std::streamsize>(this->lenBytes));
-        if (!file) {
-            throw std::runtime_error(
-            "In function void Key::save(const std::string& filepath) const: "
-            "Failed to write key data to file: " + filepath
+    if(!file.is_open()) {
+        throw std::runtime_error(
+            "In function void Key::save(const std::string& filepath) const:"
+            " Failed to open " + filepath + " for writing."
         );
     }
-    } else {
+    file.write(
+        reinterpret_cast<const char*>(this->data),
+        static_cast<std::streamsize>(this->lenBytes)
+    );
+    if(!file) {
         throw std::runtime_error(
-            "In function void Key::save(const char* const filepath): Failed to write "
-            + filepath + " file.\n"
+            "In function void Key::save(const std::string& filepath) const:"
+            " Failed to write key data to file: " + filepath
         );
     }
 }

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -179,9 +179,7 @@ void test_key_save_and_load(AESKEYLEN keyLenBits) {
 }
 
 void test_key_load_errors(AESKEYLEN keyLenBits) {
-    KeyhppTest keytest(keyLenBits);
-    size_t keyLengthBytes = static_cast<size_t>(keyLenBits)/8;
-
+    // Non-existent file must throw.
     try {
         CipherFortis::Key key("non_existent_file.bin");
         FAIL() << "Loading from non-existent file should throw exception";
@@ -189,55 +187,20 @@ void test_key_load_errors(AESKEYLEN keyLenBits) {
         // expected
     }
 
-    const char* wrong_header_file = "wrong_header.bin";
+    // File whose size is not 16, 24, or 32 bytes must throw.
+    const char* wrong_size_file = "wrong_size.bin";
     {
-        std::ofstream ofs1(wrong_header_file, std::ios::binary);
-        ofs1.write("WRONG!", 6);
-        uint16_t valid_len = static_cast<uint16_t>(keytest.getKeyLenBits());
-        ofs1.write(reinterpret_cast<char*>(&valid_len), 2);
-        uint8_t dummy_key[32] = {0};
-        ofs1.write(reinterpret_cast<char*>(dummy_key), keyLengthBytes);
+        std::ofstream ofs(wrong_size_file, std::ios::binary);
+        uint8_t dummy[10] = {0};
+        ofs.write(reinterpret_cast<char*>(dummy), sizeof(dummy));
     }
     try {
-        CipherFortis::Key key(wrong_header_file);
-        FAIL() << "Loading file with wrong header should throw exception";
+        CipherFortis::Key key(wrong_size_file);
+        FAIL() << "Loading file with invalid size should throw exception";
     } catch (const std::exception&) {
         // expected
     }
-    std::remove(wrong_header_file);
-
-    const char* invalid_length_file = "invalid_length.bin";
-    {
-        std::ofstream ofs2(invalid_length_file, std::ios::binary);
-        ofs2.write("AESKEY", 6);
-        uint16_t invalid_len = 512;
-        ofs2.write(reinterpret_cast<char*>(&invalid_len), 2);
-        uint8_t dummy_key[32] = {0};
-        ofs2.write(reinterpret_cast<char*>(dummy_key), keyLengthBytes);
-    }
-    try {
-        CipherFortis::Key key(invalid_length_file);
-        FAIL() << "Loading file with invalid key length should throw exception";
-    } catch (const std::exception&) {
-        // expected
-    }
-    std::remove(invalid_length_file);
-
-    const char* truncated_file = "truncated.bin";
-    {
-        std::ofstream ofs3(truncated_file, std::ios::binary);
-        ofs3.write("AESKEY", 6);
-        uint16_t key_len = static_cast<uint16_t>(keytest.getKeyLenBits());
-        ofs3.write(reinterpret_cast<char*>(&key_len), 2);
-        uint8_t dummy_key[32] = {0};
-        ofs3.write(reinterpret_cast<char*>(dummy_key), 8);
-    }
-    try {
-        CipherFortis::Key key(truncated_file);
-    } catch (const std::exception&) {
-        // acceptable — truncated file may or may not throw
-    }
-    std::remove(truncated_file);
+    std::remove(wrong_size_file);
 }
 
 void test_key_memory_management(AESKEYLEN keyLenBits) {


### PR DESCRIPTION
# Remove proprietary key file format in favour of raw bytes

The Key file constructor and save() function previously used an ad-hoc binary format: a 6-byte AESKEY magic string followed by a 2-byte key length, then the key bytes. This made key files incompatible with any external tool that works with raw AES key material.

## Changes
- Key::save() now writes only the raw key bytes — no header, no metadata.
- Key(const std::string& filepath) opens the file with std::ios::ate to determine its size, infers the key length from that size (16 → 128-bit, 24 → 192-bit, 32 → 256-bit), and throws std::invalid_argument for any other size. The magic-string validation logic is removed entirely.
- Updated test_key.cpp: the header- and length-field-aware error tests are replaced with a single test that verifies a file of invalid size is rejected.

## Why
The old format embedded metadata that was only meaningful to this library. Raw key files are the de-facto standard — compatible with OpenSSL, test vectors, HSM tooling, and anything else that deals in AES keys. The key length is fully determined by file size, so nometadata is needed.

## Commits
- **refactor(key): use raw bytes for file I/O, infer key length from file size**
- **test(key): replace header-aware load error tests with raw-bytes checks**
