### PR TITLE
Refactor/test infrastructure followup

### DIFF
--- a/tests/include/asset_factory.hpp
+++ b/tests/include/asset_factory.hpp
@@ -11,9 +11,27 @@ public:
     virtual fs::path    make_valid(const fs::path& dir) const = 0;
     virtual fs::path    make_large(const fs::path& dir) const = 0;
     virtual std::string extension()                     const = 0;
-    virtual bool        is_binary()                     const { return true; }
+    virtual bool        is_binary()   const { return true; }
+    virtual bool        is_lossless() const { return true; }
 
     // Non-virtual: format-independent implementations.
     fs::path make_corrupt(const fs::path& dir) const;
     fs::path make_empty  (const fs::path& dir) const;
+
+    /**
+     * @brief Verifies that `roundtripped` is a valid asset of this format
+     *        and faithfully represents the content of `original`.
+     *
+     * The default implementation performs a byte-for-byte comparison of the
+     * two files, which is correct for lossless formats (binary, text).
+     * Raster format subclasses should override this to verify that the file
+     * is loadable and has the expected dimensions via
+     * RasterImage::verify_saved_file.
+     *
+     * @return true if the roundtrip is considered successful for this format.
+     */
+    virtual bool verify_roundtrip(
+        const fs::path& original,
+        const fs::path& roundtripped
+    ) const;
 };

--- a/tests/include/bitmap_asset_factory.hpp
+++ b/tests/include/bitmap_asset_factory.hpp
@@ -6,4 +6,9 @@ public:
     fs::path    make_valid(const fs::path& dir) const override; // 32x32 BMP
     fs::path    make_large(const fs::path& dir) const override; // 4096x4096 BMP
     std::string extension()                     const override; // "bmp"
+
+    bool verify_roundtrip(
+        const fs::path& original,
+        const fs::path& roundtripped
+    ) const override;
 };

--- a/tests/include/system_workflows.hpp
+++ b/tests/include/system_workflows.hpp
@@ -30,9 +30,6 @@ public:
     // SYSTEM TEST 3: Performance and Large File Handling
     bool test_large_file_performance();
 
-    // SYSTEM TEST 4: JPEG encryption saves output as PNG
-    bool test_jpeg_encryption_saves_as_png();
-
     // SYSTEM TEST 5: Metadata round-trip (encrypt with --metadata, decrypt with --metadata)
     bool test_metadata_round_trip();
 
@@ -55,5 +52,21 @@ private:
 
     void setupTestEnvironment();
 }; // class SystemTests
+
+/**
+ * @brief Verifies that the CLI redirects JPEG encryption output to PNG.
+ *
+ * This scenario is specific to JPEG and is not part of the generic
+ * SystemTests workflow suite. It is a standalone test of the CLI's
+ * lossy-format redirect behaviour.
+ *
+ * @param executable_path  Path to the image_encryptor binary under test.
+ * @param working_dir      Writable directory for temporary test assets.
+ *                         The caller is responsible for its lifecycle.
+ */
+bool test_jpeg_saves_as_png(
+    const std::string& executable_path,
+    const fs::path&    working_dir
+);
 
 } // namespace CommandLineToolsTest

--- a/tests/src/asset_factory.cpp
+++ b/tests/src/asset_factory.cpp
@@ -19,3 +19,12 @@ fs::path AssetFactory::make_empty(const fs::path& dir) const {
     TestUtils::IO::write_binary_file(p, 0);
     return p;
 }
+
+bool AssetFactory::verify_roundtrip(
+    const fs::path& original,
+    const fs::path& roundtripped
+) const {
+    // Default: byte-for-byte comparison. Correct for binary and text formats
+    // that do not re-encode on save.
+    return TestUtils::IO::read_file(original) == TestUtils::IO::read_file(roundtripped);
+}

--- a/tests/src/bitmap_asset_factory.cpp
+++ b/tests/src/bitmap_asset_factory.cpp
@@ -1,5 +1,6 @@
 #include "../include/bitmap_asset_factory.hpp"
 #include "../include/raster_asset_utils.hpp"
+#include "../../file-handlers/include/bitmap.hpp"
 
 fs::path BitmapAssetFactory::make_valid(const fs::path& dir) const {
     fs::path p = dir / "valid.bmp";
@@ -15,4 +16,14 @@ fs::path BitmapAssetFactory::make_large(const fs::path& dir) const {
 
 std::string BitmapAssetFactory::extension() const {
     return "bmp";
+}
+
+bool BitmapAssetFactory::verify_roundtrip(
+    const fs::path& original,
+    const fs::path& roundtripped
+) const {
+    File::Bitmap ref(original);
+    ref.load();
+    // Checks that stbi_info reports matching width, height, and channels.
+    return ref.verify_saved_file(roundtripped);
 }

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -222,28 +222,31 @@ bool SystemTests::test_error_scenarios() {
     return success;
 }
 
-// SYSTEM TEST 4: JPEG encryption saves output as PNG
-bool SystemTests::test_jpeg_encryption_saves_as_png() {
+// JPEG standalone test — not a SystemTests method; JPEG-specific behaviour only.
+bool CommandLineToolsTest::test_jpeg_saves_as_png(
+    const std::string& executable_path,
+    const fs::path&    working_dir
+) {
     bool success = true;
 
     // Generate key
+    const fs::path keyPath = working_dir / "key.bin";
     std::string gen_key_cmd =
-        this->executable_path + " --generate-key --output " +
-        this->keyPath.string();
+        executable_path + " --generate-key --output " + keyPath.string();
     SystemUtils::execute_cli_command(gen_key_cmd);
 
     // Create a JPEG input
-    const fs::path jpegInput  = this->env_.path() / "jpeg_input.jpg";
-    const fs::path encJpg     = this->env_.path() / "enc.jpg";
-    const fs::path encPng     = this->env_.path() / "enc.png";
-    const fs::path decJpg     = this->env_.path() / "dec.jpg";
+    const fs::path jpegInput = working_dir / "jpeg_input.jpg";
+    const fs::path encJpg    = working_dir / "enc.jpg";
+    const fs::path encPng    = working_dir / "enc.png";
+    const fs::path decJpg    = working_dir / "dec.jpg";
 
     RasterImageFixture::createValidJpeg(jpegInput, 32, 32);
 
     // Encrypt — tool should redirect output to enc.png
     std::string encrypt_cmd =
-        this->executable_path + " --key " + this->keyPath.string() +
-        " --input " + jpegInput.string() +
+        executable_path + " --key " + keyPath.string() +
+        " --input "  + jpegInput.string() +
         " --output " + encJpg.string() +
         " --iv 00112233445566778899AABBCCDDEEFF";
     int enc_result = SystemUtils::execute_cli_command(encrypt_cmd);
@@ -260,8 +263,8 @@ bool SystemTests::test_jpeg_encryption_saves_as_png() {
 
     // Decrypt the PNG back to JPEG
     std::string decrypt_cmd =
-        this->executable_path + " --decrypt --key " + this->keyPath.string() +
-        " --input " + encPng.string() +
+        executable_path + " --decrypt --key " + keyPath.string() +
+        " --input "  + encPng.string() +
         " --output " + decJpg.string() +
         " --iv 00112233445566778899AABBCCDDEEFF";
     int dec_result = SystemUtils::execute_cli_command(decrypt_cmd);

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -5,10 +5,6 @@
 #include <gtest/gtest.h>
 #include "../include/system_workflows.hpp"
 #include "../include/file_write_utils.hpp"
-#include "../../file-handlers/include/bitmap.hpp"
-#include "../../file-handlers/include/png_image.hpp"
-#include "../../file-handlers/include/jpeg_image.hpp"
-#include "../../core-crypto/include/key.hpp"
 #include <filesystem>
 #include <cstdlib>
 #include <string>
@@ -350,102 +346,41 @@ bool SystemTests::test_file_validity() {
     );
 
     const std::string iv = " --iv 00112233445566778899AABBCCDDEEFF";
+    const fs::path enc = env_.path() / (
+        "validity_enc." + factory_.extension()
+    );
+    const fs::path dec = env_.path() / (
+        "validity_dec." + factory_.extension()
+    );
 
-    // ── BMP ──────────────────────────────────────────────────────────────────
-    {
-        const fs::path enc = env_.path() / "validity_enc.bmp";
-        const fs::path dec = env_.path() / "validity_dec.bmp";
+    // Encrypt
+    SystemUtils::execute_cli_command(
+        this->executable_path + " --key " + this->keyPath.string() +
+        " --input "  + this->originalValidPath.string() +
+        " --output " + enc.string() + iv
+    );
 
-        SystemUtils::execute_cli_command(
-            this->executable_path + " --key " + keyPath.string() +
-            " --input "  + originalValidPath.string() +
-            " --output " + enc.string() + iv
-        );
-        SystemUtils::execute_cli_command(
-            this->executable_path + " --decrypt --key " + keyPath.string() +
-            " --input "  + enc.string() +
-            " --output " + dec.string() + iv
-        );
+    // Encrypted file must be a valid, loadable asset of this format.
+    bool encValid = factory_.verify_roundtrip(this->originalValidPath, enc);
+    EXPECT_TRUE(encValid)
+        << factory_.extension()
+        << ": encrypted file must be a valid loadable asset";
+    success &= encValid;
 
-        File::Bitmap ref(originalValidPath);
-        ref.load();
+    // Decrypt
+    SystemUtils::execute_cli_command(
+        this->executable_path + " --decrypt --key " + this->keyPath.string() +
+        " --input "  + enc.string() +
+        " --output " + dec.string() + iv
+    );
 
-        bool encValid = ref.verify_saved_file(enc);
-        EXPECT_TRUE(encValid)
-            << "BMP: encrypted file must be a valid loadable image";
-        success &= encValid;
-
-        bool decValid = ref.verify_saved_file(dec);
-        EXPECT_TRUE(decValid)
-            << "BMP: decrypted file must be a valid loadable image";
-        success &= decValid;
-    }
-
-    // ── PNG ───────────────────────────────────────────────────────────────────
-    {
-        const fs::path pngOrig = env_.path() / "validity_orig.png";
-        const fs::path enc     = env_.path() / "validity_enc.png";
-        const fs::path dec     = env_.path() / "validity_dec.png";
-        RasterImageFixture::createValidPng(pngOrig, 32, 32);
-
-        SystemUtils::execute_cli_command(
-            this->executable_path + " --key " + keyPath.string() +
-            " --input "  + pngOrig.string() +
-            " --output " + enc.string() + iv
-        );
-        SystemUtils::execute_cli_command(
-            this->executable_path + " --decrypt --key " + keyPath.string() +
-            " --input "  + enc.string() +
-            " --output " + dec.string() + iv
-        );
-
-        File::PNG ref(pngOrig);
-        ref.load();
-
-        bool encValid = ref.verify_saved_file(enc);
-        EXPECT_TRUE(encValid)
-            << "PNG: encrypted file must be a valid loadable image";
-        success &= encValid;
-
-        bool decValid = ref.verify_saved_file(dec);
-        EXPECT_TRUE(decValid)
-            << "PNG: decrypted file must be a valid loadable image";
-        success &= decValid;
-    }
-
-    // ── JPEG (saved as PNG on encrypt) ────────────────────────────────────────
-    {
-        const fs::path jpegOrig = env_.path() / "validity_orig.jpg";
-        const fs::path encPng   = env_.path() / "validity_enc_jpeg.png";
-        const fs::path dec      = env_.path() / "validity_dec_jpeg.jpg";
-        RasterImageFixture::createValidJpeg(jpegOrig, 32, 32);
-
-        SystemUtils::execute_cli_command(
-            this->executable_path + " --key " + keyPath.string() +
-            " --input "  + jpegOrig.string() +
-            " --output " + encPng.string().substr(
-                0, encPng.string().size() - 4
-            ) + ".jpg" + iv
-        );
-        SystemUtils::execute_cli_command(
-            this->executable_path + " --decrypt --key " + keyPath.string() +
-            " --input "  + encPng.string() +
-            " --output " + dec.string() + iv
-        );
-
-        File::JPEG ref(jpegOrig);
-        ref.load();
-
-        bool encValid = ref.verify_saved_file(encPng);
-        EXPECT_TRUE(encValid)
-            << "JPEG->PNG: encrypted file must be a valid loadable image";
-        success &= encValid;
-
-        bool decValid = ref.verify_saved_file(dec);
-        EXPECT_TRUE(decValid)
-            << "JPEG decrypted file must be a valid loadable image";
-        success &= decValid;
-    }
+    // Decrypted file must match the original according to this format's
+    // definition of a successful roundtrip.
+    bool decValid = factory_.verify_roundtrip(this->originalValidPath, dec);
+    EXPECT_TRUE(decValid)
+        << factory_.extension()
+        << ": decrypted file must match the original";
+    success &= decValid;
 
     return success;
 }

--- a/tests/system/test_image_encryptorcpp.cpp
+++ b/tests/system/test_image_encryptorcpp.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include "../include/system_workflows.hpp"
 #include "../include/bitmap_asset_factory.hpp"
+#include "../include/test_environment.hpp"
 
 namespace cltt = CommandLineToolsTest;
 
@@ -25,9 +26,8 @@ TEST(SystemTest, LargeFilePerformance) {
 }
 
 TEST(SystemTest, JpegEncryptSavesAsPng) {
-    BitmapAssetFactory factory;
-    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory);
-    EXPECT_TRUE(st.test_jpeg_encryption_saves_as_png());
+    TestEnvironment env("test_data/jpeg_saves_as_png");
+    EXPECT_TRUE(cltt::test_jpeg_saves_as_png(IMAGE_ENCRYPTOR_PATH, env.path()));
 }
 
 TEST(SystemTest, MetadataRoundTrip) {


### PR DESCRIPTION
# Remove format-specific logic from SystemTests

## Context                                                                                                                                             
                                                                                                                                                      
SystemTests is designed to be format-agnostic — it accepts any AssetFactory subclass and drives the same set of workflow tests regardless of format.
Two methods violated this guarantee:                                                                                                               
                                                                                                                                                      
- test_jpeg_encryption_saves_as_png was a member of SystemTests but hardcoded JPEG entirely, ignoring the factory it received.                      
- test_file_validity contained three hardcoded format blocks (BMP, PNG, JPEG) that constructed concrete File:: types directly, making it impossible to extend without touching SystemTests.                                                                                                             
                                                                                                                                                    
## Changes                                                                                                                                             
                                                                                                                                                    
### Phase 1 — test_jpeg_encryption_saves_as_png → free function                                                                                         
  
The method is promoted to CommandLineToolsTest::test_jpeg_saves_as_png(executable_path, working_dir), a standalone free function that is honest about its scope: it tests a CLI behaviour specific to JPEG input (the lossy-format PNG redirect). The TEST() block now constructs a TestEnvironment directly and calls the free function, with no factory involved.                                                                                     
                                                                                                                                                    
### Phase 2 — test_file_validity driven by AssetFactory

A new virtual method verify_roundtrip(original, roundtripped) is added to AssetFactory with a byte-for-byte default (correct for lossless, non-raster formats). BitmapAssetFactory overrides it to use RasterImage::verify_saved_file, which checks that the roundtripped file is loadable and has matching dimensions. test_file_validity is rewritten as a single format-agnostic encrypt → verify → decrypt → verify flow. The three hardcoded format blocks and four dead includes (bitmap.hpp, png_image.hpp, jpeg_image.hpp, key.hpp) are removed from system_workflows.cpp.                  

A companion virtual bool is_lossless() const (default true) is added to AssetFactory alongside verify_roundtrip, co-locating all format-characteristic properties in one place for use when JPEG and PNG drivers are added.
                                                                                                                                                      
## Result                                                                                                                                            

SystemTests now contains five purely format-agnostic methods. Adding a PNG or JPEG system test driver requires only implementing make_valid, make_large, extension, and verify_roundtrip on the new factory — SystemTests is never touched.