### PR TITLE
refactor(test_image_encryptor): parametrize system tests over image formats

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(ciphfortis_test_fixtures STATIC
     src/bitmap_asset_factory.cpp
     src/file_base_fixture.cpp
     src/file_write_utils.cpp
+    scr/jpeg_asset_factory.cpp
     src/png_asset_factory.cpp
     src/raster_asset_utils.cpp
     src/raster_image_fixture.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(ciphfortis_test_fixtures STATIC
     src/bitmap_asset_factory.cpp
     src/file_base_fixture.cpp
     src/file_write_utils.cpp
-    png_asset_factory.cpp
+    src/png_asset_factory.cpp
     src/raster_asset_utils.cpp
     src/raster_image_fixture.cpp
     src/system_workflows.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(ciphfortis_test_fixtures STATIC
     src/bitmap_asset_factory.cpp
     src/file_base_fixture.cpp
     src/file_write_utils.cpp
-    scr/jpeg_asset_factory.cpp
+    src/jpeg_asset_factory.cpp
     src/png_asset_factory.cpp
     src/raster_asset_utils.cpp
     src/raster_image_fixture.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(ciphfortis_test_fixtures STATIC
     src/bitmap_asset_factory.cpp
     src/file_base_fixture.cpp
     src/file_write_utils.cpp
+    png_asset_factory.cpp
     src/raster_asset_utils.cpp
     src/raster_image_fixture.cpp
     src/system_workflows.cpp

--- a/tests/include/asset_factory.hpp
+++ b/tests/include/asset_factory.hpp
@@ -11,6 +11,9 @@ public:
     virtual fs::path    make_valid(const fs::path& dir) const = 0;
     virtual fs::path    make_large(const fs::path& dir) const = 0;
     virtual std::string extension()                     const = 0;
+    // Returns the extension the CLI will actually write to when encrypting
+    // an asset of this format. For most formats this equals extension().
+    virtual std::string encrypted_extension() const { return extension(); }
     virtual bool        is_binary()   const { return true; }
     virtual bool        is_lossless() const { return true; }
 
@@ -31,7 +34,6 @@ public:
      * @return true if the roundtrip is considered successful for this format.
      */
     virtual bool verify_roundtrip(
-        const fs::path& original,
-        const fs::path& roundtripped
+        const fs::path& original,const fs::path& roundtripped
     ) const;
 };

--- a/tests/include/jpeg_asset_factory.hpp
+++ b/tests/include/jpeg_asset_factory.hpp
@@ -6,6 +6,9 @@ public:
     fs::path    make_valid(const fs::path& dir) const override; // 32x32 JPEG
     fs::path    make_large(const fs::path& dir) const override; // 4096x4096 JPEG
     std::string extension ()                    const override; // "jpg"
+    // For JPEG it returns "png" because the CLI redirects lossy input to a
+    // lossless container before encrypting.
+    std::string encrypted_extension()           const override; // "png"
     bool        is_lossless()                   const override { return false; }
 
     bool verify_roundtrip(

--- a/tests/include/jpeg_asset_factory.hpp
+++ b/tests/include/jpeg_asset_factory.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "asset_factory.hpp"
+
+class JpegAssetFactory : public AssetFactory {
+public:
+    fs::path    make_valid(const fs::path& dir) const override; // 32x32 JPEG
+    fs::path    make_large(const fs::path& dir) const override; // 4096x4096 JPEG
+    std::string extension ()                    const override; // "jpg"
+    bool        is_lossless()                   const override { return false; }
+
+    bool verify_roundtrip(
+        const fs::path& original,
+        const fs::path& roundtripped
+    ) const override;
+};

--- a/tests/include/png_asset_factory.hpp
+++ b/tests/include/png_asset_factory.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "asset_factory.hpp"
+
+class PngAssetFactory : public AssetFactory {
+public:
+    fs::path    make_valid(const fs::path& dir) const override; // 32x32 PNG
+    fs::path    make_large(const fs::path& dir) const override; // 4096x4096 PNG
+    std::string extension ()                    const override; // "png"
+
+    bool verify_roundtrip(
+        const fs::path& original,
+        const fs::path& roundtripped
+    ) const override;
+};

--- a/tests/src/jpeg_asset_factory.cpp
+++ b/tests/src/jpeg_asset_factory.cpp
@@ -10,11 +10,12 @@ fs::path JpegAssetFactory::make_valid(const fs::path& dir) const {
 
 fs::path JpegAssetFactory::make_large(const fs::path& dir) const {
     fs::path p = dir / "large.jpg";
-    TestUtils::Raster::make_jpeg(p, 4096, 4096);
+    TestUtils::Raster::make_jpeg(p, 2048, 2048);
     return p;
 }
 
 std::string JpegAssetFactory::extension() const { return "jpg"; }
+std::string JpegAssetFactory::encrypted_extension() const { return "png"; }
 
 bool JpegAssetFactory::verify_roundtrip(
     const fs::path& original,

--- a/tests/src/jpeg_asset_factory.cpp
+++ b/tests/src/jpeg_asset_factory.cpp
@@ -10,7 +10,7 @@ fs::path JpegAssetFactory::make_valid(const fs::path& dir) const {
 
 fs::path JpegAssetFactory::make_large(const fs::path& dir) const {
     fs::path p = dir / "large.jpg";
-    TestUtils::Raster::make_jpeg(p, 2048, 2048);
+    TestUtils::Raster::make_jpeg(p, 4096, 3072);
     return p;
 }
 

--- a/tests/src/jpeg_asset_factory.cpp
+++ b/tests/src/jpeg_asset_factory.cpp
@@ -1,0 +1,30 @@
+#include "../include/jpeg_asset_factory.hpp"
+#include "../include/raster_asset_utils.hpp"
+#include "../../file-handlers/include/jpeg_image.hpp"
+
+fs::path JpegAssetFactory::make_valid(const fs::path& dir) const {
+    fs::path p = dir / "valid.jpg";
+    TestUtils::Raster::make_jpeg(p, 32, 32);
+    return p;
+}
+
+fs::path JpegAssetFactory::make_large(const fs::path& dir) const {
+    fs::path p = dir / "large.jpg";
+    TestUtils::Raster::make_jpeg(p, 4096, 4096);
+    return p;
+}
+
+std::string JpegAssetFactory::extension() const { return "jpg"; }
+
+bool JpegAssetFactory::verify_roundtrip(
+    const fs::path& original,
+    const fs::path& roundtripped
+) const {
+    File::JPEG ref(original);
+    ref.load();
+    // Byte comparison is intentionally skipped: lossy re-encoding after
+    // decryption means the output will never be byte-identical to the
+    // input even on a correct implementation. Dimension match is the
+    // strongest assertion available for this format.
+    return ref.verify_saved_file(roundtripped);
+}

--- a/tests/src/png_asset_factory.cpp
+++ b/tests/src/png_asset_factory.cpp
@@ -1,0 +1,26 @@
+#include "../include/png_asset_factory.hpp"
+#include "../include/raster_asset_utils.hpp"
+#include "../../file-handlers/include/png_image.hpp"
+
+fs::path PngAssetFactory::make_valid(const fs::path& dir) const {
+    fs::path p = dir / "valid.png";
+    TestUtils::Raster::make_png(p, 32, 32);
+    return p;
+}
+
+fs::path PngAssetFactory::make_large(const fs::path& dir) const {
+    fs::path p = dir / "large.png";
+    TestUtils::Raster::make_png(p, 4096, 4096);
+    return p;
+}
+
+std::string PngAssetFactory::extension() const { return "png"; }
+
+bool PngAssetFactory::verify_roundtrip(
+    const fs::path& original,
+    const fs::path& roundtripped
+) const {
+    File::PNG ref(original);
+    ref.load();
+    return ref.verify_saved_file(roundtripped);
+}

--- a/tests/src/png_asset_factory.cpp
+++ b/tests/src/png_asset_factory.cpp
@@ -10,7 +10,7 @@ fs::path PngAssetFactory::make_valid(const fs::path& dir) const {
 
 fs::path PngAssetFactory::make_large(const fs::path& dir) const {
     fs::path p = dir / "large.png";
-    TestUtils::Raster::make_png(p, 4096, 4096);
+    TestUtils::Raster::make_png(p, 2048, 2048);
     return p;
 }
 

--- a/tests/src/png_asset_factory.cpp
+++ b/tests/src/png_asset_factory.cpp
@@ -10,7 +10,7 @@ fs::path PngAssetFactory::make_valid(const fs::path& dir) const {
 
 fs::path PngAssetFactory::make_large(const fs::path& dir) const {
     fs::path p = dir / "large.png";
-    TestUtils::Raster::make_png(p, 2048, 2048);
+    TestUtils::Raster::make_png(p, 4096, 3072);
     return p;
 }
 

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -30,13 +30,13 @@ void SystemTests::setupTestEnvironment() {
         "does_not_exist." + factory_.extension()
     );
     this->encryptedOriginalValidPath = env_.path() / (
-        "encrypted_original_valid." + factory_.extension()
+        "encrypted_original_valid." + factory_.encrypted_extension()
     );
     this->decryptedOriginalValidPath = env_.path() / (
         "decrypted_original_valid." + factory_.extension()
     );
     this->encryptedOriginalLargePath = env_.path() / (
-        "encrypted_original_large." + factory_.extension()
+        "encrypted_original_large." + factory_.encrypted_extension()
     );
     this->decryptedOriginalLargePath = env_.path() / (
         "decrypted_original_large." + factory_.extension()
@@ -280,7 +280,7 @@ bool SystemTests::test_metadata_round_trip() {
 
     const fs::path metaPath      = this->env_.path() / "meta.json";
     const fs::path encryptedPath = env_.path() / (
-        "meta_enc." + factory_.extension()
+        "meta_enc." + factory_.encrypted_extension()
     );
     const fs::path decryptedPath = env_.path() / (
         "meta_dec." + factory_.extension()
@@ -347,7 +347,7 @@ bool SystemTests::test_file_validity() {
 
     const std::string iv = " --iv 00112233445566778899AABBCCDDEEFF";
     const fs::path enc = env_.path() / (
-        "validity_enc." + factory_.extension()
+        "validity_enc." + factory_.encrypted_extension()
     );
     const fs::path dec = env_.path() / (
         "validity_dec." + factory_.extension()

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -427,6 +427,7 @@ bool SystemTests::test_large_file_performance() {
         encrypt_end - start_time
     );
 
+    auto original_size  = std::filesystem::file_size(this->originalLargePath);
     bool encryptSucceeded = (encrypt_result == 0);
     EXPECT_TRUE(encryptSucceeded) << "Large file encryption should succeed";
     success &= encryptSucceeded;
@@ -434,7 +435,8 @@ bool SystemTests::test_large_file_performance() {
     if (encryptSucceeded) {
         bool encryptFast = (encrypt_duration.count() < 10000);
         EXPECT_TRUE(encryptFast)
-            << "48MB encryption should complete within 10 seconds (lasted "
+            << original_size
+            << " byte encryption should complete within 10 seconds (lasted "
             << encrypt_duration.count() << " milliseconds)";
         success &= encryptFast;
     }
@@ -456,6 +458,7 @@ bool SystemTests::test_large_file_performance() {
         decrypt_end - decrypt_start
     );
 
+    auto encrypted_size = std::filesystem::file_size(this->encryptedOriginalLargePath);
     bool decryptSucceeded = (decrypt_result == 0);
     EXPECT_TRUE(decryptSucceeded) << "Large file decryption should succeed";
     success &= decryptSucceeded;
@@ -463,18 +466,25 @@ bool SystemTests::test_large_file_performance() {
     if (decryptSucceeded) {
         bool decryptFast = (decrypt_duration.count() < 10000);
         EXPECT_TRUE(decryptFast)
-            << "48MB decryption should complete within 10 seconds (lasted "
+            << encrypted_size
+            << " byte decryption should complete within 10 seconds (lasted "
             << decrypt_duration.count() << " milliseconds)";
         success &= decryptFast;
     }
 
     // Verify integrity
-    auto original_size  = std::filesystem::file_size(this->originalLargePath);
-    auto decrypted_size = std::filesystem::file_size(this->decryptedOriginalLargePath);
+    if (factory_.is_lossless()){
+        auto decrypted_size = std::filesystem::file_size(this->decryptedOriginalLargePath);
 
-    bool sizeMatches = (original_size == decrypted_size);
-    EXPECT_TRUE(sizeMatches) << "Large file should maintain size after roundtrip";
-    success &= sizeMatches;
-
+        bool sizeMatches = (original_size == decrypted_size);
+        EXPECT_TRUE(sizeMatches) << "Large file should maintain size after roundtrip";
+        success &= sizeMatches;
+    } else {
+        bool formatValid = factory_.verify_roundtrip(
+            this->originalLargePath, this->decryptedOriginalLargePath
+        );
+        EXPECT_TRUE(formatValid) << "Decrypted file must be a valid, loadable asset";
+        success &= formatValid;
+    }
     return success;
 }

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -145,7 +145,9 @@ bool SystemTests::test_file_encryption_workflow() {
             }
         }
     } else { // For lossy formats only verify the validity of the output file
-        bool formatValid = factory_.verify_roundtrip(originalValidPath, decryptedPath);
+        bool formatValid = factory_.verify_roundtrip(
+            this->originalValidPath, this->decryptedOriginalValidPath
+        );
         EXPECT_TRUE(formatValid) << "Decrypted file must be a valid, loadable asset";
         success &= formatValid;
     }
@@ -336,11 +338,13 @@ bool SystemTests::test_metadata_round_trip() {
         std::vector<uint8_t> decrypted = SystemUtils::read_file(decryptedPath, true);
 
         if (factory_.is_lossless()) {
-            bool contentMatches = (decrypted_content == test_content);
+            bool contentMatches = (decrypted == original);
             EXPECT_TRUE(contentMatches) << "Decrypted content should match original";
             success &= contentMatches;
         } else {
-            bool formatValid = factory_.verify_roundtrip(originalValidPath, decryptedPath);
+            bool formatValid = factory_.verify_roundtrip(
+                this->originalValidPath, decryptedPath
+            );
             EXPECT_TRUE(formatValid) << "Decrypted file must be a valid, loadable asset";
             success &= formatValid;
         }

--- a/tests/src/system_workflows.cpp
+++ b/tests/src/system_workflows.cpp
@@ -121,27 +121,33 @@ bool SystemTests::test_file_encryption_workflow() {
         this->decryptedOriginalValidPath, factory_.is_binary()
     );
 
-    bool contentMatches = (decrypted_content == test_content);
-    EXPECT_TRUE(contentMatches) << "Decrypted content should match original";
-    success &= contentMatches;
+    if (factory_.is_lossless()) {
+        bool contentMatches = (decrypted_content == test_content);
+        EXPECT_TRUE(contentMatches) << "Decrypted content should match original";
+        success &= contentMatches;
 
-    if (!contentMatches) {
-        std::cout << "Original size: " << test_content.size() << std::endl;
-        std::cout << "Decrypted size: " << decrypted_content.size() << std::endl;
+        if (!contentMatches) {
+            std::cout << "Original size: " << test_content.size() << std::endl;
+            std::cout << "Decrypted size: " << decrypted_content.size() << std::endl;
 
-        if (test_content.size() == decrypted_content.size()) {
-            for (size_t i = 0; i < test_content.size(); i++) {
-                if (test_content[i] != decrypted_content[i]) {
-                    std::cout << "First mismatch at byte " <<
-                        i << std::endl;
-                    std::cout << "Original: " << std::hex <<
-                        static_cast<int>(test_content[i]) << std::endl;
-                    std::cout << "Decrypted: " << std::hex<<
-                        static_cast<int>(decrypted_content[i]) << std::endl;
-                    break;
+            if (test_content.size() == decrypted_content.size()) {
+                for (size_t i = 0; i < test_content.size(); i++) {
+                    if (test_content[i] != decrypted_content[i]) {
+                        std::cout << "First mismatch at byte " <<
+                            i << std::endl;
+                        std::cout << "Original: " << std::hex <<
+                            static_cast<int>(test_content[i]) << std::endl;
+                        std::cout << "Decrypted: " << std::hex<<
+                            static_cast<int>(decrypted_content[i]) << std::endl;
+                        break;
+                    }
                 }
             }
         }
+    } else { // For lossy formats only verify the validity of the output file
+        bool formatValid = factory_.verify_roundtrip(originalValidPath, decryptedPath);
+        EXPECT_TRUE(formatValid) << "Decrypted file must be a valid, loadable asset";
+        success &= formatValid;
     }
 
     return success;
@@ -328,9 +334,16 @@ bool SystemTests::test_metadata_round_trip() {
             this->originalValidPath, true
         );
         std::vector<uint8_t> decrypted = SystemUtils::read_file(decryptedPath, true);
-        bool contentMatches = (original == decrypted);
-        EXPECT_TRUE(contentMatches) << "Decrypted content should match original";
-        success &= contentMatches;
+
+        if (factory_.is_lossless()) {
+            bool contentMatches = (decrypted_content == test_content);
+            EXPECT_TRUE(contentMatches) << "Decrypted content should match original";
+            success &= contentMatches;
+        } else {
+            bool formatValid = factory_.verify_roundtrip(originalValidPath, decryptedPath);
+            EXPECT_TRUE(formatValid) << "Decrypted file must be a valid, loadable asset";
+            success &= formatValid;
+        }
     }
 
     return success;

--- a/tests/system/test_image_encryptorcpp.cpp
+++ b/tests/system/test_image_encryptorcpp.cpp
@@ -1,43 +1,69 @@
-// System/E2E Testing for AES Image Encryption Tool
+// tests/system/test_image_encryptorcpp.cpp
 
 #include <gtest/gtest.h>
 #include "../include/system_workflows.hpp"
+#include "../include/asset_factory.hpp"
 #include "../include/bitmap_asset_factory.hpp"
+#include "../include/png_asset_factory.hpp"
+#include "../include/jpeg_asset_factory.hpp"
 #include "../include/test_environment.hpp"
 
 namespace cltt = CommandLineToolsTest;
 
-TEST(SystemTest, FileEncryptionWorkflow) {
-    BitmapAssetFactory factory;
-    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory);
+// ── Parameterised suite ───────────────────────────────────────────────────────
+
+class ImageEncryptorSystemTest
+    : public ::testing::TestWithParam<const AssetFactory*> {
+protected:
+    const AssetFactory& factory() const { return *GetParam(); }
+};
+
+TEST_P(ImageEncryptorSystemTest, FileEncryptionWorkflow) {
+    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory());
     EXPECT_TRUE(st.test_file_encryption_workflow());
 }
 
-TEST(SystemTest, ErrorScenarios) {
-    BitmapAssetFactory factory;
-    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory);
+TEST_P(ImageEncryptorSystemTest, ErrorScenarios) {
+    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory());
     EXPECT_TRUE(st.test_error_scenarios());
 }
 
-TEST(SystemTest, LargeFilePerformance) {
-    BitmapAssetFactory factory;
-    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory);
+TEST_P(ImageEncryptorSystemTest, LargeFilePerformance) {
+    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory());
     EXPECT_TRUE(st.test_large_file_performance());
 }
+
+TEST_P(ImageEncryptorSystemTest, MetadataRoundTrip) {
+    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory());
+    EXPECT_TRUE(st.test_metadata_round_trip());
+}
+
+TEST_P(ImageEncryptorSystemTest, FileValidityAfterEncryptDecrypt) {
+    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory());
+    EXPECT_TRUE(st.test_file_validity());
+}
+
+// Factory instances — stateless, safe to share across the suite.
+static BitmapAssetFactory bitmapFactory;
+static PngAssetFactory    pngFactory;
+static JpegAssetFactory   jpegFactory;
+
+INSTANTIATE_TEST_SUITE_P(
+    ImageFormats,
+    ImageEncryptorSystemTest,
+    ::testing::Values(
+        static_cast<const AssetFactory*>(&bitmapFactory),
+        static_cast<const AssetFactory*>(&pngFactory),
+        static_cast<const AssetFactory*>(&jpegFactory)
+    ),
+    [](const ::testing::TestParamInfo<const AssetFactory*>& info) {
+        return info.param->extension();
+    }
+);
+
+// ── JPEG standalone test ──────────────────────────────────────────────────────
 
 TEST(SystemTest, JpegEncryptSavesAsPng) {
     TestEnvironment env("test_data/jpeg_saves_as_png");
     EXPECT_TRUE(cltt::test_jpeg_saves_as_png(IMAGE_ENCRYPTOR_PATH, env.path()));
-}
-
-TEST(SystemTest, MetadataRoundTrip) {
-    BitmapAssetFactory factory;
-    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory);
-    EXPECT_TRUE(st.test_metadata_round_trip());
-}
-
-TEST(SystemTest, FileValidityAfterEncryptDecrypt) {
-    BitmapAssetFactory factory;
-    cltt::SystemTests st(IMAGE_ENCRYPTOR_PATH, factory);
-    EXPECT_TRUE(st.test_file_validity());
 }


### PR DESCRIPTION
## Summary

The system tests in test_image_encryptorcpp.cpp previously hard-coded BitmapAssetFactory in every test case, meaning JPEG and PNG formats had no coverage from the system/E2E suite. This PR refactors the suite to use GTest's TEST_P / INSTANTIATE_TEST_SUITE_P so the same five workflows (file encryption, error scenarios, large file performance, metadata round-trip, file validity) now run against BMP, PNG, and JPEG.

## New asset factories:
- PngAssetFactory — lossless; verify_roundtrip does a byte-exact comparison.
- JpegAssetFactory — lossy; encrypted_extension() returns "png" because the CLI re-encodes JPEG input into a lossless PNG container before encrypting. verify_roundtrip checks that the output is a valid, loadable image rather than requiring byte equality.

## AssetFactory interface changes:
- Added encrypted_extension() virtual method (defaults to extension()). This allows SystemTests to build the correct output path when the CLI writes to a different container format than the input.

## system_workflows.cpp changes:                                                                                                                       
- Encrypted output paths now use factory_.encrypted_extension() instead of factory_.extension().
- Content-comparison assertions are now gated on factory_.is_lossless(). For lossy formats, the workflow falls back to verify_roundtrip() (valid file check) instead of a byte-exact diff.
- Performance test error messages now report the actual file size instead of the hard-coded "48MB" string.

## Issues closed
This refactor closes #23 

## Commits
- **test(asset_factory): create asset factory for png images**
- **build(tests): add png asset factory**
- **fix(test_build): correct png asset factory path**
- **test(asset_factory): create asset factory for jpeg images**
- **build(test): add png asset factory**
- **fix(src): correct path**
- **refactor(test_image_encryptor): migrate from static TEST() to parametrized TEST_P() under image format**
- **feat(asset-factory): write encrypted_extension function**
- **feat(jpeg_asset_factory): overryde encrypted_extension function to return png**
- **fix(system_workflows): modify encrypted output extension**
- **fix(asset_factories): update large image dimensions (4096 -> 2048)**
- **fix(sytem_workflows): guard against lossy formats in rountrip content comparison**
- **fix(system_workflows): substitude undeclared variables**
- **chore(asset_factory): update large image dimensions**
- **fix(system_workflows): guard against lossy format in file integrity**
